### PR TITLE
Add exitCodes, output, and envsFromOutput fields

### DIFF
--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -530,7 +530,141 @@
           "testEndStatement": "[comment]: # (test end)",
           "stepStatementOpen": "[comment]: # (step",
           "stepStatementClose": ")",
-          "markup": []
+          "markup": [
+            {
+              "name": "onscreenText",
+              "regex": [
+                "\\*\\*.+?\\*\\*"
+              ],
+              "actions": [
+                "find"
+              ]
+            },
+            {
+              "name": "emphasis",
+              "regex": [
+                "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
+              ],
+              "actions": [
+                "find"
+              ]
+            },
+            {
+              "name": "image",
+              "regex": [
+                "!\\[.+?\\]\\(.+?\\)"
+              ],
+              "actions": [
+                "checkLink"
+              ]
+            },
+            {
+              "name": "hyperlink",
+              "regex": [
+                "(?<!!)\\[.+?\\]\\(.+?\\)"
+              ],
+              "actions": [
+                "checkLink",
+                "goTo",
+                "httpRequest"
+              ]
+            },
+            {
+              "name": "orderedList",
+              "regex": [
+                "(?<=\n) *?[0-9][0-9]?[0-9]?.\\s*.*"
+              ]
+            },
+            {
+              "name": "unorderedList",
+              "regex": [
+                "(?<=\n) *?\\*.\\s*.*",
+                "(?<=\n) *?-.\\s*.*"
+              ]
+            },
+            {
+              "name": "codeInline",
+              "regex": [
+                "(?<!`)`(?!`).+?(?<!`)`(?!`)"
+              ],
+              "actions": [
+                "runShell",
+                "setVariables",
+                "httpRequest"
+              ]
+            },
+            {
+              "name": "codeBlock",
+              "regex": [
+                "(?=(```))(\\w|\\W)*(?<=```)"
+              ],
+              "actions": [
+                "runShell",
+                "setVariables",
+                "httpRequest"
+              ]
+            },
+            {
+              "name": "interaction",
+              "regex": [
+                "[cC]lick",
+                "[tT]ap",
+                "[tT]ouch",
+                "[sS]elect",
+                "[cC]hoose",
+                "[tT]oggle",
+                "[eE]nable",
+                "[dD]isable",
+                "[tT]urn [oO][ff|n]",
+                "[tT]ype",
+                "[eE]nter",
+                "[sS]end",
+                "[aA]dd",
+                "[rR]emove",
+                "[dD]elete",
+                "[uU]pload",
+                "[dD]ownload",
+                "[sS]croll",
+                "[sS]earch",
+                "[fF]ilter",
+                "[sS]ort",
+                "[cC]opy",
+                "[pP]aste",
+                "[cC]ut",
+                "[rR]eplace",
+                "[cC]lear",
+                "[rR]efresh",
+                "[rR]evert",
+                "[rR]estore",
+                "[rR]eset",
+                "[lL]ogin",
+                "[lL]ogout",
+                "[sS]ign [iI]n",
+                "[sS]ign [oO]ut",
+                "[sS]ubmit",
+                "[cC]ancel",
+                "[cC]lose",
+                "[aA]ccept",
+                "[dD]ecline",
+                "[dD]eny",
+                "[rR]eject",
+                "[rR]etry",
+                "[rR]estart",
+                "[rR]esume"
+              ],
+              "actions": [
+                "checkLink",
+                "find",
+                "goTo",
+                "httpRequest",
+                "runShell",
+                "saveScreenshot",
+                "setVariables",
+                "typeKeys",
+                "wait"
+              ]
+            }
+          ]
         },
         {
           "name": "AsciiDoc",

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -102,6 +102,23 @@
       ],
       "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
       "description": "This is a test!"
+    },
+    {
+      "action": "runShell",
+      "command": "echo",
+      "args": [
+        "setup"
+      ],
+      "exitCodes": [
+        0
+      ],
+      "output": "/.*?/",
+      "setVariables": [
+        {
+          "name": "TEST",
+          "regex": ".*"
+        }
+      ]
     }
   ]
 }

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -31,6 +31,51 @@
         ]
       },
       "default": []
+    },
+    "exitCodes": {
+      "type": "array",
+      "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+      "items": {
+        "oneOf": [
+          {
+            "type": "integer"
+          }
+        ]
+      },
+      "default": [
+        0
+      ]
+    },
+    "output": {
+      "type": "string",
+      "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+    },
+    "envsFromOutput": {
+      "type": "array",
+      "description": "Extract environment variables from the command's output.",
+      "items": {
+        "oneOf": [
+          {
+            "description": "",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable to set.",
+                "type": "string"
+              },
+              "regex": {
+                "description": "Regex to extract the environment variable from the command's output.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "regex"
+            ]
+          }
+        ]
+      },
+      "default": []
     }
   },
   "dynamicDefaults": {

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -105,6 +105,14 @@
     },
     {
       "action": "runShell",
+      "command": "docker run hello-world",
+      "exitCodes": [
+        0
+      ],
+      "output": "Hello from Docker!"
+    },
+    {
+      "action": "runShell",
       "command": "echo",
       "args": [
         "setup"

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -50,7 +50,7 @@
       "type": "string",
       "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
     },
-    "envsFromOutput": {
+    "setVariables": {
       "type": "array",
       "description": "Extract environment variables from the command's output.",
       "items": {

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -113,6 +113,13 @@
     },
     {
       "action": "runShell",
+      "command": "false",
+      "exitCodes": [
+        1
+      ]
+    },
+    {
+      "action": "runShell",
       "command": "echo",
       "args": [
         "setup"

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -738,6 +738,14 @@
                         },
                         {
                           "action": "runShell",
+                          "command": "docker run hello-world",
+                          "exitCodes": [
+                            0
+                          ],
+                          "output": "Hello from Docker!"
+                        },
+                        {
+                          "action": "runShell",
                           "command": "echo",
                           "args": [
                             "setup"

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -664,6 +664,51 @@
                             ]
                           },
                           "default": []
+                        },
+                        "exitCodes": {
+                          "type": "array",
+                          "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "integer"
+                              }
+                            ]
+                          },
+                          "default": [
+                            0
+                          ]
+                        },
+                        "output": {
+                          "type": "string",
+                          "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                        },
+                        "envsFromOutput": {
+                          "type": "array",
+                          "description": "Extract environment variables from the command's output.",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "description": "",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the environment variable to set.",
+                                    "type": "string"
+                                  },
+                                  "regex": {
+                                    "description": "Regex to extract the environment variable from the command's output.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "regex"
+                                ]
+                              }
+                            ]
+                          },
+                          "default": []
                         }
                       },
                       "dynamicDefaults": {

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -746,6 +746,13 @@
                         },
                         {
                           "action": "runShell",
+                          "command": "false",
+                          "exitCodes": [
+                            1
+                          ]
+                        },
+                        {
+                          "action": "runShell",
                           "command": "echo",
                           "args": [
                             "setup"

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -683,7 +683,7 @@
                           "type": "string",
                           "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
                         },
-                        "envsFromOutput": {
+                        "setVariables": {
                           "type": "array",
                           "description": "Extract environment variables from the command's output.",
                           "items": {

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -735,6 +735,23 @@
                           ],
                           "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
                           "description": "This is a test!"
+                        },
+                        {
+                          "action": "runShell",
+                          "command": "echo",
+                          "args": [
+                            "setup"
+                          ],
+                          "exitCodes": [
+                            0
+                          ],
+                          "output": "/.*?/",
+                          "setVariables": [
+                            {
+                              "name": "TEST",
+                              "regex": ".*"
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -594,6 +594,14 @@
               },
               {
                 "action": "runShell",
+                "command": "docker run hello-world",
+                "exitCodes": [
+                  0
+                ],
+                "output": "Hello from Docker!"
+              },
+              {
+                "action": "runShell",
                 "command": "echo",
                 "args": [
                   "setup"

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -539,7 +539,7 @@
                 "type": "string",
                 "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
               },
-              "envsFromOutput": {
+              "setVariables": {
                 "type": "array",
                 "description": "Extract environment variables from the command's output.",
                 "items": {

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -520,6 +520,51 @@
                   ]
                 },
                 "default": []
+              },
+              "exitCodes": {
+                "type": "array",
+                "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    }
+                  ]
+                },
+                "default": [
+                  0
+                ]
+              },
+              "output": {
+                "type": "string",
+                "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+              },
+              "envsFromOutput": {
+                "type": "array",
+                "description": "Extract environment variables from the command's output.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "description": "",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable to set.",
+                          "type": "string"
+                        },
+                        "regex": {
+                          "description": "Regex to extract the environment variable from the command's output.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "regex"
+                      ]
+                    }
+                  ]
+                },
+                "default": []
               }
             },
             "dynamicDefaults": {

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -591,6 +591,23 @@
                 ],
                 "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
                 "description": "This is a test!"
+              },
+              {
+                "action": "runShell",
+                "command": "echo",
+                "args": [
+                  "setup"
+                ],
+                "exitCodes": [
+                  0
+                ],
+                "output": "/.*?/",
+                "setVariables": [
+                  {
+                    "name": "TEST",
+                    "regex": ".*"
+                  }
+                ]
               }
             ]
           },

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -602,6 +602,13 @@
               },
               {
                 "action": "runShell",
+                "command": "false",
+                "exitCodes": [
+                  1
+                ]
+              },
+              {
+                "action": "runShell",
                 "command": "echo",
                 "args": [
                   "setup"

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -611,7 +611,141 @@
             "testEndStatement": "[comment]: # (test end)",
             "stepStatementOpen": "[comment]: # (step",
             "stepStatementClose": ")",
-            "markup": []
+            "markup": [
+              {
+                "name": "onscreenText",
+                "regex": [
+                  "\\*\\*.+?\\*\\*"
+                ],
+                "actions": [
+                  "find"
+                ]
+              },
+              {
+                "name": "emphasis",
+                "regex": [
+                  "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
+                ],
+                "actions": [
+                  "find"
+                ]
+              },
+              {
+                "name": "image",
+                "regex": [
+                  "!\\[.+?\\]\\(.+?\\)"
+                ],
+                "actions": [
+                  "checkLink"
+                ]
+              },
+              {
+                "name": "hyperlink",
+                "regex": [
+                  "(?<!!)\\[.+?\\]\\(.+?\\)"
+                ],
+                "actions": [
+                  "checkLink",
+                  "goTo",
+                  "httpRequest"
+                ]
+              },
+              {
+                "name": "orderedList",
+                "regex": [
+                  "(?<=\n) *?[0-9][0-9]?[0-9]?.\\s*.*"
+                ]
+              },
+              {
+                "name": "unorderedList",
+                "regex": [
+                  "(?<=\n) *?\\*.\\s*.*",
+                  "(?<=\n) *?-.\\s*.*"
+                ]
+              },
+              {
+                "name": "codeInline",
+                "regex": [
+                  "(?<!`)`(?!`).+?(?<!`)`(?!`)"
+                ],
+                "actions": [
+                  "runShell",
+                  "setVariables",
+                  "httpRequest"
+                ]
+              },
+              {
+                "name": "codeBlock",
+                "regex": [
+                  "(?=(```))(\\w|\\W)*(?<=```)"
+                ],
+                "actions": [
+                  "runShell",
+                  "setVariables",
+                  "httpRequest"
+                ]
+              },
+              {
+                "name": "interaction",
+                "regex": [
+                  "[cC]lick",
+                  "[tT]ap",
+                  "[tT]ouch",
+                  "[sS]elect",
+                  "[cC]hoose",
+                  "[tT]oggle",
+                  "[eE]nable",
+                  "[dD]isable",
+                  "[tT]urn [oO][ff|n]",
+                  "[tT]ype",
+                  "[eE]nter",
+                  "[sS]end",
+                  "[aA]dd",
+                  "[rR]emove",
+                  "[dD]elete",
+                  "[uU]pload",
+                  "[dD]ownload",
+                  "[sS]croll",
+                  "[sS]earch",
+                  "[fF]ilter",
+                  "[sS]ort",
+                  "[cC]opy",
+                  "[pP]aste",
+                  "[cC]ut",
+                  "[rR]eplace",
+                  "[cC]lear",
+                  "[rR]efresh",
+                  "[rR]evert",
+                  "[rR]estore",
+                  "[rR]eset",
+                  "[lL]ogin",
+                  "[lL]ogout",
+                  "[sS]ign [iI]n",
+                  "[sS]ign [oO]ut",
+                  "[sS]ubmit",
+                  "[cC]ancel",
+                  "[cC]lose",
+                  "[aA]ccept",
+                  "[dD]ecline",
+                  "[dD]eny",
+                  "[rR]eject",
+                  "[rR]etry",
+                  "[rR]estart",
+                  "[rR]esume"
+                ],
+                "actions": [
+                  "checkLink",
+                  "find",
+                  "goTo",
+                  "httpRequest",
+                  "runShell",
+                  "saveScreenshot",
+                  "setVariables",
+                  "typeKeys",
+                  "wait"
+                ]
+              }
+            ]
           },
           {
             "name": "AsciiDoc",

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -1811,7 +1811,7 @@
         "type": "string",
         "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
       },
-      "envsFromOutput": {
+      "setVariables": {
         "type": "array",
         "description": "Extract environment variables from the command's output.",
         "items": {
@@ -2750,7 +2750,7 @@
                             "type": "string",
                             "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
                           },
-                          "envsFromOutput": {
+                          "setVariables": {
                             "type": "array",
                             "description": "Extract environment variables from the command's output.",
                             "items": {
@@ -4010,7 +4010,7 @@
                   "type": "string",
                   "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
                 },
-                "envsFromOutput": {
+                "setVariables": {
                   "type": "array",
                   "description": "Extract environment variables from the command's output.",
                   "items": {

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -2008,6 +2008,13 @@
       },
       {
         "action": "runShell",
+        "command": "false",
+        "exitCodes": [
+          1
+        ]
+      },
+      {
+        "action": "runShell",
         "command": "echo",
         "args": [
           "setup"
@@ -2969,6 +2976,13 @@
                               0
                             ],
                             "output": "Hello from Docker!"
+                          },
+                          {
+                            "action": "runShell",
+                            "command": "false",
+                            "exitCodes": [
+                              1
+                            ]
                           },
                           {
                             "action": "runShell",
@@ -4254,6 +4268,13 @@
                     0
                   ],
                   "output": "Hello from Docker!"
+                },
+                {
+                  "action": "runShell",
+                  "command": "false",
+                  "exitCodes": [
+                    1
+                  ]
                 },
                 {
                   "action": "runShell",

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -2000,6 +2000,14 @@
       },
       {
         "action": "runShell",
+        "command": "docker run hello-world",
+        "exitCodes": [
+          0
+        ],
+        "output": "Hello from Docker!"
+      },
+      {
+        "action": "runShell",
         "command": "echo",
         "args": [
           "setup"
@@ -2953,6 +2961,14 @@
                             ],
                             "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
                             "description": "This is a test!"
+                          },
+                          {
+                            "action": "runShell",
+                            "command": "docker run hello-world",
+                            "exitCodes": [
+                              0
+                            ],
+                            "output": "Hello from Docker!"
                           },
                           {
                             "action": "runShell",
@@ -4230,6 +4246,14 @@
                   ],
                   "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
                   "description": "This is a test!"
+                },
+                {
+                  "action": "runShell",
+                  "command": "docker run hello-world",
+                  "exitCodes": [
+                    0
+                  ],
+                  "output": "Hello from Docker!"
                 },
                 {
                   "action": "runShell",

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -1792,6 +1792,51 @@
           ]
         },
         "default": []
+      },
+      "exitCodes": {
+        "type": "array",
+        "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+        "items": {
+          "oneOf": [
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "default": [
+          0
+        ]
+      },
+      "output": {
+        "type": "string",
+        "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+      },
+      "envsFromOutput": {
+        "type": "array",
+        "description": "Extract environment variables from the command's output.",
+        "items": {
+          "oneOf": [
+            {
+              "description": "",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Name of the environment variable to set.",
+                  "type": "string"
+                },
+                "regex": {
+                  "description": "Regex to extract the environment variable from the command's output.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "regex"
+              ]
+            }
+          ]
+        },
+        "default": []
       }
     },
     "dynamicDefaults": {
@@ -2682,6 +2727,51 @@
                               "oneOf": [
                                 {
                                   "type": "string"
+                                }
+                              ]
+                            },
+                            "default": []
+                          },
+                          "exitCodes": {
+                            "type": "array",
+                            "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "integer"
+                                }
+                              ]
+                            },
+                            "default": [
+                              0
+                            ]
+                          },
+                          "output": {
+                            "type": "string",
+                            "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                          },
+                          "envsFromOutput": {
+                            "type": "array",
+                            "description": "Extract environment variables from the command's output.",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "description": "",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the environment variable to set.",
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "description": "Regex to extract the environment variable from the command's output.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "regex"
+                                  ]
                                 }
                               ]
                             },
@@ -3897,6 +3987,51 @@
                     "oneOf": [
                       {
                         "type": "string"
+                      }
+                    ]
+                  },
+                  "default": []
+                },
+                "exitCodes": {
+                  "type": "array",
+                  "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "default": [
+                    0
+                  ]
+                },
+                "output": {
+                  "type": "string",
+                  "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                },
+                "envsFromOutput": {
+                  "type": "array",
+                  "description": "Extract environment variables from the command's output.",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "description": "",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the environment variable to set.",
+                            "type": "string"
+                          },
+                          "regex": {
+                            "description": "Regex to extract the environment variable from the command's output.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "regex"
+                        ]
                       }
                     ]
                   },

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -1997,6 +1997,23 @@
         ],
         "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
         "description": "This is a test!"
+      },
+      {
+        "action": "runShell",
+        "command": "echo",
+        "args": [
+          "setup"
+        ],
+        "exitCodes": [
+          0
+        ],
+        "output": "/.*?/",
+        "setVariables": [
+          {
+            "name": "TEST",
+            "regex": ".*"
+          }
+        ]
       }
     ]
   },
@@ -2936,6 +2953,23 @@
                             ],
                             "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
                             "description": "This is a test!"
+                          },
+                          {
+                            "action": "runShell",
+                            "command": "echo",
+                            "args": [
+                              "setup"
+                            ],
+                            "exitCodes": [
+                              0
+                            ],
+                            "output": "/.*?/",
+                            "setVariables": [
+                              {
+                                "name": "TEST",
+                                "regex": ".*"
+                              }
+                            ]
                           }
                         ]
                       },
@@ -4196,6 +4230,23 @@
                   ],
                   "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
                   "description": "This is a test!"
+                },
+                {
+                  "action": "runShell",
+                  "command": "echo",
+                  "args": [
+                    "setup"
+                  ],
+                  "exitCodes": [
+                    0
+                  ],
+                  "output": "/.*?/",
+                  "setVariables": [
+                    {
+                      "name": "TEST",
+                      "regex": ".*"
+                    }
+                  ]
                 }
               ]
             },

--- a/src/schemas/src_schemas/config_v2.schema.json
+++ b/src/schemas/src_schemas/config_v2.schema.json
@@ -319,7 +319,106 @@
           "testEndStatement": "[comment]: # (test end)",
           "stepStatementOpen": "[comment]: # (step",
           "stepStatementClose": ")",
-          "markup": []
+          "markup": [
+            {
+              "name": "onscreenText",
+              "regex": ["\\*\\*.+?\\*\\*"],
+              "actions": ["find"]
+            },
+            {
+              "name": "emphasis",
+              "regex": ["(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"],
+              "actions": ["find"]
+            },
+            {
+              "name": "image",
+              "regex": ["!\\[.+?\\]\\(.+?\\)"],
+              "actions": ["checkLink"]
+            },
+            {
+              "name": "hyperlink",
+              "regex": ["(?<!!)\\[.+?\\]\\(.+?\\)"],
+              "actions": ["checkLink", "goTo", "httpRequest"]
+            },
+            {
+              "name": "orderedList",
+              "regex": ["(?<=\n) *?[0-9][0-9]?[0-9]?.\\s*.*"]
+            },
+            {
+              "name": "unorderedList",
+              "regex": ["(?<=\n) *?\\*.\\s*.*", "(?<=\n) *?-.\\s*.*"]
+            },
+            {
+              "name": "codeInline",
+              "regex": ["(?<!`)`(?!`).+?(?<!`)`(?!`)"],
+              "actions": ["runShell", "setVariables", "httpRequest"]
+            },
+            {
+              "name": "codeBlock",
+              "regex": ["(?=(```))(\\w|\\W)*(?<=```)"],
+              "actions": ["runShell", "setVariables", "httpRequest"]
+            },
+            {
+              "name": "interaction",
+              "regex": [
+                "[cC]lick",
+                "[tT]ap",
+                "[tT]ouch",
+                "[sS]elect",
+                "[cC]hoose",
+                "[tT]oggle",
+                "[eE]nable",
+                "[dD]isable",
+                "[tT]urn [oO][ff|n]",
+                "[tT]ype",
+                "[eE]nter",
+                "[sS]end",
+                "[aA]dd",
+                "[rR]emove",
+                "[dD]elete",
+                "[uU]pload",
+                "[dD]ownload",
+                "[sS]croll",
+                "[sS]earch",
+                "[fF]ilter",
+                "[sS]ort",
+                "[cC]opy",
+                "[pP]aste",
+                "[cC]ut",
+                "[rR]eplace",
+                "[cC]lear",
+                "[rR]efresh",
+                "[rR]evert",
+                "[rR]estore",
+                "[rR]eset",
+                "[lL]ogin",
+                "[lL]ogout",
+                "[sS]ign [iI]n",
+                "[sS]ign [oO]ut",
+                "[sS]ubmit",
+                "[cC]ancel",
+                "[cC]lose",
+                "[aA]ccept",
+                "[dD]ecline",
+                "[dD]eny",
+                "[rR]eject",
+                "[rR]etry",
+                "[rR]estart",
+                "[rR]esume"
+              ],
+              "actions": [
+                "checkLink",
+                "find",
+                "goTo",
+                "httpRequest",
+                "runShell",
+                "saveScreenshot",
+                "setVariables",
+                "typeKeys",
+                "wait"
+              ]
+            }
+          ]
         },
         {
           "name": "AsciiDoc",

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -31,6 +31,46 @@
         ]
       },
       "default": []
+    },
+    "exitCodes": {
+      "type": "array",
+      "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+      "items": {
+        "oneOf": [
+          {
+            "type": "integer"
+          }
+        ]
+      },
+      "default": [0]
+    },
+    "output": {
+      "type": "string",
+      "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+    },
+    "envsFromOutput": {
+      "type": "array",
+      "description": "Extract environment variables from the command's output.",
+      "items": {
+        "oneOf": [
+          {
+            "description": "",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable to set.",
+                "type": "string"
+              },
+              "regex": {
+                "description": "Regex to extract the environment variable from the command's output.",
+                "type": "string"
+              }
+            },
+            "required": ["name", "regex"]
+          }
+        ]
+      },
+      "default": []
     }
   },
   "dynamicDefaults": {

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -93,6 +93,12 @@
     },
     {
       "action": "runShell",
+      "command": "docker run hello-world",
+      "exitCodes": [0],
+      "output": "Hello from Docker!"
+    },
+    {
+      "action": "runShell",
       "command": "echo",
       "args": ["setup"],
       "exitCodes": [0],

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -99,6 +99,11 @@
     },
     {
       "action": "runShell",
+      "command": "false",
+      "exitCodes": [1]
+    },
+    {
+      "action": "runShell",
       "command": "echo",
       "args": ["setup"],
       "exitCodes": [0],

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -48,7 +48,7 @@
       "type": "string",
       "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
     },
-    "envsFromOutput": {
+    "setVariables": {
       "type": "array",
       "description": "Extract environment variables from the command's output.",
       "items": {

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -90,6 +90,19 @@
       "args": ["hello-world"],
       "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
       "description": "This is a test!"
+    },
+    {
+      "action": "runShell",
+      "command": "echo",
+      "args": ["setup"],
+      "exitCodes": [0],
+      "output": "/.*?/",
+      "setVariables": [
+        {
+          "name": "TEST",
+          "regex": ".*"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This pull request adds the exitCodes, output, and envsFromOutput fields to the existing codebase. These fields allow for more control and customization when running commands and extracting information from their output.