### PR TITLE
Update matchText description to include regular expressions

### DIFF
--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -611,7 +611,7 @@
                                   },
                                   "matchText": {
                                     "type": "string",
-                                    "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                                    "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
                                   },
                                   "moveTo": {
                                     "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -663,6 +663,33 @@
                                         }
                                       }
                                     ]
+                                  },
+                                  "setVariables": {
+                                    "type": "array",
+                                    "description": "Extract environment variables from the element's text.",
+                                    "items": {
+                                      "oneOf": [
+                                        {
+                                          "description": "",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the environment variable to set.",
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "description": "Regex to extract the environment variable from the element's text.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "regex"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "default": []
                                   }
                                 },
                                 "required": [
@@ -700,6 +727,16 @@
                                       ],
                                       "delay": 100
                                     }
+                                  },
+                                  {
+                                    "action": "find",
+                                    "selector": "[title=ResultsCount]",
+                                    "setVariables": [
+                                      {
+                                        "name": "resultsCount",
+                                        "regex": ".*"
+                                      }
+                                    ]
                                   }
                                 ]
                               },

--- a/src/schemas/output_schemas/find_v2.schema.json
+++ b/src/schemas/output_schemas/find_v2.schema.json
@@ -79,6 +79,33 @@
           }
         }
       ]
+    },
+    "setVariables": {
+      "type": "array",
+      "description": "Extract environment variables from the element's text.",
+      "items": {
+        "oneOf": [
+          {
+            "description": "",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable to set.",
+                "type": "string"
+              },
+              "regex": {
+                "description": "Regex to extract the environment variable from the element's text.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "regex"
+            ]
+          }
+        ]
+      },
+      "default": []
     }
   },
   "required": [
@@ -116,6 +143,16 @@
         ],
         "delay": 100
       }
+    },
+    {
+      "action": "find",
+      "selector": "[title=ResultsCount]",
+      "setVariables": [
+        {
+          "name": "resultsCount",
+          "regex": ".*"
+        }
+      ]
     }
   ]
 }

--- a/src/schemas/output_schemas/find_v2.schema.json
+++ b/src/schemas/output_schemas/find_v2.schema.json
@@ -27,7 +27,7 @@
     },
     "matchText": {
       "type": "string",
-      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
     },
     "moveTo": {
       "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -992,7 +992,7 @@
                         },
                         "matchText": {
                           "type": "string",
-                          "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                          "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
                         },
                         "moveTo": {
                           "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -1121,6 +1121,33 @@
                               }
                             }
                           ]
+                        },
+                        "setVariables": {
+                          "type": "array",
+                          "description": "Extract environment variables from the element's text.",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "description": "",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the environment variable to set.",
+                                    "type": "string"
+                                  },
+                                  "regex": {
+                                    "description": "Regex to extract the environment variable from the element's text.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "regex"
+                                ]
+                              }
+                            ]
+                          },
+                          "default": []
                         }
                       },
                       "required": [
@@ -1158,6 +1185,16 @@
                             ],
                             "delay": 100
                           }
+                        },
+                        {
+                          "action": "find",
+                          "selector": "[title=ResultsCount]",
+                          "setVariables": [
+                            {
+                              "name": "resultsCount",
+                              "regex": ".*"
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -848,7 +848,7 @@
               },
               "matchText": {
                 "type": "string",
-                "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
               },
               "moveTo": {
                 "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -977,6 +977,33 @@
                     }
                   }
                 ]
+              },
+              "setVariables": {
+                "type": "array",
+                "description": "Extract environment variables from the element's text.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "description": "",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable to set.",
+                          "type": "string"
+                        },
+                        "regex": {
+                          "description": "Regex to extract the environment variable from the element's text.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "regex"
+                      ]
+                    }
+                  ]
+                },
+                "default": []
               }
             },
             "required": [
@@ -1014,6 +1041,16 @@
                   ],
                   "delay": 100
                 }
+              },
+              {
+                "action": "find",
+                "selector": "[title=ResultsCount]",
+                "setVariables": [
+                  {
+                    "name": "resultsCount",
+                    "regex": ".*"
+                  }
+                ]
               }
             ]
           },

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -1503,6 +1503,33 @@
             }
           }
         ]
+      },
+      "setVariables": {
+        "type": "array",
+        "description": "Extract environment variables from the element's text.",
+        "items": {
+          "oneOf": [
+            {
+              "description": "",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Name of the environment variable to set.",
+                  "type": "string"
+                },
+                "regex": {
+                  "description": "Regex to extract the environment variable from the element's text.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "regex"
+              ]
+            }
+          ]
+        },
+        "default": []
       }
     },
     "required": [
@@ -1540,6 +1567,16 @@
           ],
           "delay": 100
         }
+      },
+      {
+        "action": "find",
+        "selector": "[title=ResultsCount]",
+        "setVariables": [
+          {
+            "name": "resultsCount",
+            "regex": ".*"
+          }
+        ]
       }
     ]
   },
@@ -3354,6 +3391,33 @@
                                 }
                               }
                             ]
+                          },
+                          "setVariables": {
+                            "type": "array",
+                            "description": "Extract environment variables from the element's text.",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "description": "",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the environment variable to set.",
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "description": "Regex to extract the environment variable from the element's text.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "regex"
+                                  ]
+                                }
+                              ]
+                            },
+                            "default": []
                           }
                         },
                         "required": [
@@ -3391,6 +3455,16 @@
                               ],
                               "delay": 100
                             }
+                          },
+                          {
+                            "action": "find",
+                            "selector": "[title=ResultsCount]",
+                            "setVariables": [
+                              {
+                                "name": "resultsCount",
+                                "regex": ".*"
+                              }
+                            ]
                           }
                         ]
                       },
@@ -4646,6 +4720,33 @@
                       }
                     }
                   ]
+                },
+                "setVariables": {
+                  "type": "array",
+                  "description": "Extract environment variables from the element's text.",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "description": "",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the environment variable to set.",
+                            "type": "string"
+                          },
+                          "regex": {
+                            "description": "Regex to extract the environment variable from the element's text.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "regex"
+                        ]
+                      }
+                    ]
+                  },
+                  "default": []
                 }
               },
               "required": [
@@ -4683,6 +4784,16 @@
                     ],
                     "delay": 100
                   }
+                },
+                {
+                  "action": "find",
+                  "selector": "[title=ResultsCount]",
+                  "setVariables": [
+                    {
+                      "name": "resultsCount",
+                      "regex": ".*"
+                    }
+                  ]
                 }
               ]
             },

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -692,7 +692,7 @@
                                     },
                                     "matchText": {
                                       "type": "string",
-                                      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                                      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
                                     },
                                     "moveTo": {
                                       "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -744,6 +744,33 @@
                                           }
                                         }
                                       ]
+                                    },
+                                    "setVariables": {
+                                      "type": "array",
+                                      "description": "Extract environment variables from the element's text.",
+                                      "items": {
+                                        "oneOf": [
+                                          {
+                                            "description": "",
+                                            "type": "object",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the environment variable to set.",
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "description": "Regex to extract the environment variable from the element's text.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "regex"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "default": []
                                     }
                                   },
                                   "required": [
@@ -781,6 +808,16 @@
                                         ],
                                         "delay": 100
                                       }
+                                    },
+                                    {
+                                      "action": "find",
+                                      "selector": "[title=ResultsCount]",
+                                      "setVariables": [
+                                        {
+                                          "name": "resultsCount",
+                                          "regex": ".*"
+                                        }
+                                      ]
                                     }
                                   ]
                                 },

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -1317,7 +1317,7 @@
       },
       "matchText": {
         "type": "string",
-        "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+        "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
       },
       "moveTo": {
         "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -3014,7 +3014,7 @@
                           },
                           "matchText": {
                             "type": "string",
-                            "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                            "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
                           },
                           "moveTo": {
                             "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -4229,7 +4229,7 @@
                 },
                 "matchText": {
                   "type": "string",
-                  "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                  "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
                 },
                 "moveTo": {
                   "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",

--- a/src/schemas/src_schemas/find_v2.schema.json
+++ b/src/schemas/src_schemas/find_v2.schema.json
@@ -62,6 +62,30 @@
           }
         }
       ]
+    },
+    "setVariables": {
+      "type": "array",
+      "description": "Extract environment variables from the element's text.",
+      "items": {
+        "oneOf": [
+          {
+            "description": "",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable to set.",
+                "type": "string"
+              },
+              "regex": {
+                "description": "Regex to extract the environment variable from the element's text.",
+                "type": "string"
+              }
+            },
+            "required": ["name", "regex"]
+          }
+        ]
+      },
+      "default": []
     }
   },
   "required": ["action", "selector"],
@@ -94,6 +118,16 @@
         "keys": ["shorthair cat"],
         "delay": 100
       }
+    },
+    {
+      "action": "find",
+      "selector": "[title=ResultsCount]",
+      "setVariables": [
+        {
+          "name": "resultsCount",
+          "regex": ".*"
+        }
+      ]
     }
   ]
 }

--- a/src/schemas/src_schemas/find_v2.schema.json
+++ b/src/schemas/src_schemas/find_v2.schema.json
@@ -27,7 +27,7 @@
     },
     "matchText": {
       "type": "string",
-      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
     },
     "moveTo": {
       "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",


### PR DESCRIPTION
This pull request updates the description of the `matchText` property in multiple files to include information about accepting regular expressions. The description now states that the `matchText` property can accept both strings and regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`.