### PR TITLE
v1.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.13.1",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Shared components for Doc Detective projects. ",
   "main": "src/index.js",
   "scripts": {

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -530,7 +530,141 @@
           "testEndStatement": "[comment]: # (test end)",
           "stepStatementOpen": "[comment]: # (step",
           "stepStatementClose": ")",
-          "markup": []
+          "markup": [
+            {
+              "name": "onscreenText",
+              "regex": [
+                "\\*\\*.+?\\*\\*"
+              ],
+              "actions": [
+                "find"
+              ]
+            },
+            {
+              "name": "emphasis",
+              "regex": [
+                "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
+              ],
+              "actions": [
+                "find"
+              ]
+            },
+            {
+              "name": "image",
+              "regex": [
+                "!\\[.+?\\]\\(.+?\\)"
+              ],
+              "actions": [
+                "checkLink"
+              ]
+            },
+            {
+              "name": "hyperlink",
+              "regex": [
+                "(?<!!)\\[.+?\\]\\(.+?\\)"
+              ],
+              "actions": [
+                "checkLink",
+                "goTo",
+                "httpRequest"
+              ]
+            },
+            {
+              "name": "orderedList",
+              "regex": [
+                "(?<=\n) *?[0-9][0-9]?[0-9]?.\\s*.*"
+              ]
+            },
+            {
+              "name": "unorderedList",
+              "regex": [
+                "(?<=\n) *?\\*.\\s*.*",
+                "(?<=\n) *?-.\\s*.*"
+              ]
+            },
+            {
+              "name": "codeInline",
+              "regex": [
+                "(?<!`)`(?!`).+?(?<!`)`(?!`)"
+              ],
+              "actions": [
+                "runShell",
+                "setVariables",
+                "httpRequest"
+              ]
+            },
+            {
+              "name": "codeBlock",
+              "regex": [
+                "(?=(```))(\\w|\\W)*(?<=```)"
+              ],
+              "actions": [
+                "runShell",
+                "setVariables",
+                "httpRequest"
+              ]
+            },
+            {
+              "name": "interaction",
+              "regex": [
+                "[cC]lick",
+                "[tT]ap",
+                "[tT]ouch",
+                "[sS]elect",
+                "[cC]hoose",
+                "[tT]oggle",
+                "[eE]nable",
+                "[dD]isable",
+                "[tT]urn [oO][ff|n]",
+                "[tT]ype",
+                "[eE]nter",
+                "[sS]end",
+                "[aA]dd",
+                "[rR]emove",
+                "[dD]elete",
+                "[uU]pload",
+                "[dD]ownload",
+                "[sS]croll",
+                "[sS]earch",
+                "[fF]ilter",
+                "[sS]ort",
+                "[cC]opy",
+                "[pP]aste",
+                "[cC]ut",
+                "[rR]eplace",
+                "[cC]lear",
+                "[rR]efresh",
+                "[rR]evert",
+                "[rR]estore",
+                "[rR]eset",
+                "[lL]ogin",
+                "[lL]ogout",
+                "[sS]ign [iI]n",
+                "[sS]ign [oO]ut",
+                "[sS]ubmit",
+                "[cC]ancel",
+                "[cC]lose",
+                "[aA]ccept",
+                "[dD]ecline",
+                "[dD]eny",
+                "[rR]eject",
+                "[rR]etry",
+                "[rR]estart",
+                "[rR]esume"
+              ],
+              "actions": [
+                "checkLink",
+                "find",
+                "goTo",
+                "httpRequest",
+                "runShell",
+                "saveScreenshot",
+                "setVariables",
+                "typeKeys",
+                "wait"
+              ]
+            }
+          ]
         },
         {
           "name": "AsciiDoc",

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -545,6 +545,22 @@
           "stepStatementOpen": "// (step",
           "stepStatementClose": ")",
           "markup": []
+        },
+        {
+          "name": "HTML/XML",
+          "extensions": [
+            ".html",
+            ".htm",
+            ".xml",
+            ".xhtml"
+          ],
+          "testStartStatementOpen": "<!-- test start",
+          "testStartStatementClose": "-->",
+          "testIgnoreStatement": "<!-- test ignore -->",
+          "testEndStatement": "<!-- test end -->",
+          "stepStatementOpen": "<!-- step",
+          "stepStatementClose": "-->",
+          "markup": []
         }
       ]
     },

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -108,7 +108,7 @@
         "detectSteps": {
           "type": "boolean",
           "description": "Whether or not to detect steps in input files based on markup regex.",
-          "default": true
+          "default": false
         },
         "mediaDirectory": {
           "description": "Path of the directory in which to store output media files.",
@@ -521,6 +521,7 @@
           "name": "Markdown",
           "extensions": [
             ".md",
+            ".markdown",
             ".mdx"
           ],
           "testStartStatementOpen": "[comment]: # (test start",
@@ -529,141 +530,21 @@
           "testEndStatement": "[comment]: # (test end)",
           "stepStatementOpen": "[comment]: # (step",
           "stepStatementClose": ")",
-          "markup": [
-            {
-              "name": "onscreenText",
-              "regex": [
-                "\\*\\*.+?\\*\\*"
-              ],
-              "actions": [
-                "find"
-              ]
-            },
-            {
-              "name": "emphasis",
-              "regex": [
-                "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
-              ],
-              "actions": [
-                "find"
-              ]
-            },
-            {
-              "name": "image",
-              "regex": [
-                "!\\[.+?\\]\\(.+?\\)"
-              ],
-              "actions": [
-                "checkLink"
-              ]
-            },
-            {
-              "name": "hyperlink",
-              "regex": [
-                "(?<!!)\\[.+?\\]\\(.+?\\)"
-              ],
-              "actions": [
-                "checkLink",
-                "goTo",
-                "httpRequest"
-              ]
-            },
-            {
-              "name": "orderedList",
-              "regex": [
-                "(?<=\n) *?[0-9][0-9]?[0-9]?.\\s*.*"
-              ]
-            },
-            {
-              "name": "unorderedList",
-              "regex": [
-                "(?<=\n) *?\\*.\\s*.*",
-                "(?<=\n) *?-.\\s*.*"
-              ]
-            },
-            {
-              "name": "codeInline",
-              "regex": [
-                "(?<!`)`(?!`).+?(?<!`)`(?!`)"
-              ],
-              "actions": [
-                "runShell",
-                "setVariables",
-                "httpRequest"
-              ]
-            },
-            {
-              "name": "codeBlock",
-              "regex": [
-                "(?=(```))(\\w|\\W)*(?<=```)"
-              ],
-              "actions": [
-                "runShell",
-                "setVariables",
-                "httpRequest"
-              ]
-            },
-            {
-              "name": "interaction",
-              "regex": [
-                "[cC]lick",
-                "[tT]ap",
-                "[tT]ouch",
-                "[sS]elect",
-                "[cC]hoose",
-                "[tT]oggle",
-                "[eE]nable",
-                "[dD]isable",
-                "[tT]urn [oO][ff|n]",
-                "[tT]ype",
-                "[eE]nter",
-                "[sS]end",
-                "[aA]dd",
-                "[rR]emove",
-                "[dD]elete",
-                "[uU]pload",
-                "[dD]ownload",
-                "[sS]croll",
-                "[sS]earch",
-                "[fF]ilter",
-                "[sS]ort",
-                "[cC]opy",
-                "[pP]aste",
-                "[cC]ut",
-                "[rR]eplace",
-                "[cC]lear",
-                "[rR]efresh",
-                "[rR]evert",
-                "[rR]estore",
-                "[rR]eset",
-                "[lL]ogin",
-                "[lL]ogout",
-                "[sS]ign [iI]n",
-                "[sS]ign [oO]ut",
-                "[sS]ubmit",
-                "[cC]ancel",
-                "[cC]lose",
-                "[aA]ccept",
-                "[dD]ecline",
-                "[dD]eny",
-                "[rR]eject",
-                "[rR]etry",
-                "[rR]estart",
-                "[rR]esume"
-              ],
-              "actions": [
-                "checkLink",
-                "find",
-                "goTo",
-                "httpRequest",
-                "runShell",
-                "saveScreenshot",
-                "setVariables",
-                "typeKeys",
-                "wait"
-              ]
-            }
-          ]
+          "markup": []
+        },
+        {
+          "name": "AsciiDoc",
+          "extensions": [
+            ".adoc",
+            ".asciidoc, .asc"
+          ],
+          "testStartStatementOpen": "// (test start",
+          "testStartStatementClose": ")",
+          "testIgnoreStatement": "// (test ignore)",
+          "testEndStatement": "// (test end)",
+          "stepStatementOpen": "// (step",
+          "stepStatementClose": ")",
+          "markup": []
         }
       ]
     },

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -31,6 +31,51 @@
         ]
       },
       "default": []
+    },
+    "exitCodes": {
+      "type": "array",
+      "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+      "items": {
+        "oneOf": [
+          {
+            "type": "integer"
+          }
+        ]
+      },
+      "default": [
+        0
+      ]
+    },
+    "output": {
+      "type": "string",
+      "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+    },
+    "setVariables": {
+      "type": "array",
+      "description": "Extract environment variables from the command's output.",
+      "items": {
+        "oneOf": [
+          {
+            "description": "",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable to set.",
+                "type": "string"
+              },
+              "regex": {
+                "description": "Regex to extract the environment variable from the command's output.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "regex"
+            ]
+          }
+        ]
+      },
+      "default": []
     }
   },
   "dynamicDefaults": {
@@ -57,6 +102,38 @@
       ],
       "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
       "description": "This is a test!"
+    },
+    {
+      "action": "runShell",
+      "command": "docker run hello-world",
+      "exitCodes": [
+        0
+      ],
+      "output": "Hello from Docker!"
+    },
+    {
+      "action": "runShell",
+      "command": "false",
+      "exitCodes": [
+        1
+      ]
+    },
+    {
+      "action": "runShell",
+      "command": "echo",
+      "args": [
+        "setup"
+      ],
+      "exitCodes": [
+        0
+      ],
+      "output": "/.*?/",
+      "setVariables": [
+        {
+          "name": "TEST",
+          "regex": ".*"
+        }
+      ]
     }
   ]
 }

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -664,6 +664,51 @@
                             ]
                           },
                           "default": []
+                        },
+                        "exitCodes": {
+                          "type": "array",
+                          "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "integer"
+                              }
+                            ]
+                          },
+                          "default": [
+                            0
+                          ]
+                        },
+                        "output": {
+                          "type": "string",
+                          "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                        },
+                        "setVariables": {
+                          "type": "array",
+                          "description": "Extract environment variables from the command's output.",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "description": "",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the environment variable to set.",
+                                    "type": "string"
+                                  },
+                                  "regex": {
+                                    "description": "Regex to extract the environment variable from the command's output.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "regex"
+                                ]
+                              }
+                            ]
+                          },
+                          "default": []
                         }
                       },
                       "dynamicDefaults": {
@@ -690,6 +735,38 @@
                           ],
                           "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
                           "description": "This is a test!"
+                        },
+                        {
+                          "action": "runShell",
+                          "command": "docker run hello-world",
+                          "exitCodes": [
+                            0
+                          ],
+                          "output": "Hello from Docker!"
+                        },
+                        {
+                          "action": "runShell",
+                          "command": "false",
+                          "exitCodes": [
+                            1
+                          ]
+                        },
+                        {
+                          "action": "runShell",
+                          "command": "echo",
+                          "args": [
+                            "setup"
+                          ],
+                          "exitCodes": [
+                            0
+                          ],
+                          "output": "/.*?/",
+                          "setVariables": [
+                            {
+                              "name": "TEST",
+                              "regex": ".*"
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -520,6 +520,51 @@
                   ]
                 },
                 "default": []
+              },
+              "exitCodes": {
+                "type": "array",
+                "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    }
+                  ]
+                },
+                "default": [
+                  0
+                ]
+              },
+              "output": {
+                "type": "string",
+                "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+              },
+              "setVariables": {
+                "type": "array",
+                "description": "Extract environment variables from the command's output.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "description": "",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable to set.",
+                          "type": "string"
+                        },
+                        "regex": {
+                          "description": "Regex to extract the environment variable from the command's output.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "regex"
+                      ]
+                    }
+                  ]
+                },
+                "default": []
               }
             },
             "dynamicDefaults": {
@@ -546,6 +591,38 @@
                 ],
                 "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
                 "description": "This is a test!"
+              },
+              {
+                "action": "runShell",
+                "command": "docker run hello-world",
+                "exitCodes": [
+                  0
+                ],
+                "output": "Hello from Docker!"
+              },
+              {
+                "action": "runShell",
+                "command": "false",
+                "exitCodes": [
+                  1
+                ]
+              },
+              {
+                "action": "runShell",
+                "command": "echo",
+                "args": [
+                  "setup"
+                ],
+                "exitCodes": [
+                  0
+                ],
+                "output": "/.*?/",
+                "setVariables": [
+                  {
+                    "name": "TEST",
+                    "regex": ".*"
+                  }
+                ]
               }
             ]
           },

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -611,7 +611,141 @@
             "testEndStatement": "[comment]: # (test end)",
             "stepStatementOpen": "[comment]: # (step",
             "stepStatementClose": ")",
-            "markup": []
+            "markup": [
+              {
+                "name": "onscreenText",
+                "regex": [
+                  "\\*\\*.+?\\*\\*"
+                ],
+                "actions": [
+                  "find"
+                ]
+              },
+              {
+                "name": "emphasis",
+                "regex": [
+                  "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
+                ],
+                "actions": [
+                  "find"
+                ]
+              },
+              {
+                "name": "image",
+                "regex": [
+                  "!\\[.+?\\]\\(.+?\\)"
+                ],
+                "actions": [
+                  "checkLink"
+                ]
+              },
+              {
+                "name": "hyperlink",
+                "regex": [
+                  "(?<!!)\\[.+?\\]\\(.+?\\)"
+                ],
+                "actions": [
+                  "checkLink",
+                  "goTo",
+                  "httpRequest"
+                ]
+              },
+              {
+                "name": "orderedList",
+                "regex": [
+                  "(?<=\n) *?[0-9][0-9]?[0-9]?.\\s*.*"
+                ]
+              },
+              {
+                "name": "unorderedList",
+                "regex": [
+                  "(?<=\n) *?\\*.\\s*.*",
+                  "(?<=\n) *?-.\\s*.*"
+                ]
+              },
+              {
+                "name": "codeInline",
+                "regex": [
+                  "(?<!`)`(?!`).+?(?<!`)`(?!`)"
+                ],
+                "actions": [
+                  "runShell",
+                  "setVariables",
+                  "httpRequest"
+                ]
+              },
+              {
+                "name": "codeBlock",
+                "regex": [
+                  "(?=(```))(\\w|\\W)*(?<=```)"
+                ],
+                "actions": [
+                  "runShell",
+                  "setVariables",
+                  "httpRequest"
+                ]
+              },
+              {
+                "name": "interaction",
+                "regex": [
+                  "[cC]lick",
+                  "[tT]ap",
+                  "[tT]ouch",
+                  "[sS]elect",
+                  "[cC]hoose",
+                  "[tT]oggle",
+                  "[eE]nable",
+                  "[dD]isable",
+                  "[tT]urn [oO][ff|n]",
+                  "[tT]ype",
+                  "[eE]nter",
+                  "[sS]end",
+                  "[aA]dd",
+                  "[rR]emove",
+                  "[dD]elete",
+                  "[uU]pload",
+                  "[dD]ownload",
+                  "[sS]croll",
+                  "[sS]earch",
+                  "[fF]ilter",
+                  "[sS]ort",
+                  "[cC]opy",
+                  "[pP]aste",
+                  "[cC]ut",
+                  "[rR]eplace",
+                  "[cC]lear",
+                  "[rR]efresh",
+                  "[rR]evert",
+                  "[rR]estore",
+                  "[rR]eset",
+                  "[lL]ogin",
+                  "[lL]ogout",
+                  "[sS]ign [iI]n",
+                  "[sS]ign [oO]ut",
+                  "[sS]ubmit",
+                  "[cC]ancel",
+                  "[cC]lose",
+                  "[aA]ccept",
+                  "[dD]ecline",
+                  "[dD]eny",
+                  "[rR]eject",
+                  "[rR]etry",
+                  "[rR]estart",
+                  "[rR]esume"
+                ],
+                "actions": [
+                  "checkLink",
+                  "find",
+                  "goTo",
+                  "httpRequest",
+                  "runShell",
+                  "saveScreenshot",
+                  "setVariables",
+                  "typeKeys",
+                  "wait"
+                ]
+              }
+            ]
           },
           {
             "name": "AsciiDoc",
@@ -1792,6 +1926,51 @@
           ]
         },
         "default": []
+      },
+      "exitCodes": {
+        "type": "array",
+        "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+        "items": {
+          "oneOf": [
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "default": [
+          0
+        ]
+      },
+      "output": {
+        "type": "string",
+        "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+      },
+      "setVariables": {
+        "type": "array",
+        "description": "Extract environment variables from the command's output.",
+        "items": {
+          "oneOf": [
+            {
+              "description": "",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Name of the environment variable to set.",
+                  "type": "string"
+                },
+                "regex": {
+                  "description": "Regex to extract the environment variable from the command's output.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "regex"
+              ]
+            }
+          ]
+        },
+        "default": []
       }
     },
     "dynamicDefaults": {
@@ -1818,6 +1997,38 @@
         ],
         "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
         "description": "This is a test!"
+      },
+      {
+        "action": "runShell",
+        "command": "docker run hello-world",
+        "exitCodes": [
+          0
+        ],
+        "output": "Hello from Docker!"
+      },
+      {
+        "action": "runShell",
+        "command": "false",
+        "exitCodes": [
+          1
+        ]
+      },
+      {
+        "action": "runShell",
+        "command": "echo",
+        "args": [
+          "setup"
+        ],
+        "exitCodes": [
+          0
+        ],
+        "output": "/.*?/",
+        "setVariables": [
+          {
+            "name": "TEST",
+            "regex": ".*"
+          }
+        ]
       }
     ]
   },
@@ -2686,6 +2897,51 @@
                               ]
                             },
                             "default": []
+                          },
+                          "exitCodes": {
+                            "type": "array",
+                            "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "integer"
+                                }
+                              ]
+                            },
+                            "default": [
+                              0
+                            ]
+                          },
+                          "output": {
+                            "type": "string",
+                            "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                          },
+                          "setVariables": {
+                            "type": "array",
+                            "description": "Extract environment variables from the command's output.",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "description": "",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the environment variable to set.",
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "description": "Regex to extract the environment variable from the command's output.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "regex"
+                                  ]
+                                }
+                              ]
+                            },
+                            "default": []
                           }
                         },
                         "dynamicDefaults": {
@@ -2712,6 +2968,38 @@
                             ],
                             "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
                             "description": "This is a test!"
+                          },
+                          {
+                            "action": "runShell",
+                            "command": "docker run hello-world",
+                            "exitCodes": [
+                              0
+                            ],
+                            "output": "Hello from Docker!"
+                          },
+                          {
+                            "action": "runShell",
+                            "command": "false",
+                            "exitCodes": [
+                              1
+                            ]
+                          },
+                          {
+                            "action": "runShell",
+                            "command": "echo",
+                            "args": [
+                              "setup"
+                            ],
+                            "exitCodes": [
+                              0
+                            ],
+                            "output": "/.*?/",
+                            "setVariables": [
+                              {
+                                "name": "TEST",
+                                "regex": ".*"
+                              }
+                            ]
                           }
                         ]
                       },
@@ -3901,6 +4189,51 @@
                     ]
                   },
                   "default": []
+                },
+                "exitCodes": {
+                  "type": "array",
+                  "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "default": [
+                    0
+                  ]
+                },
+                "output": {
+                  "type": "string",
+                  "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                },
+                "setVariables": {
+                  "type": "array",
+                  "description": "Extract environment variables from the command's output.",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "description": "",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the environment variable to set.",
+                            "type": "string"
+                          },
+                          "regex": {
+                            "description": "Regex to extract the environment variable from the command's output.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "regex"
+                        ]
+                      }
+                    ]
+                  },
+                  "default": []
                 }
               },
               "dynamicDefaults": {
@@ -3927,6 +4260,38 @@
                   ],
                   "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
                   "description": "This is a test!"
+                },
+                {
+                  "action": "runShell",
+                  "command": "docker run hello-world",
+                  "exitCodes": [
+                    0
+                  ],
+                  "output": "Hello from Docker!"
+                },
+                {
+                  "action": "runShell",
+                  "command": "false",
+                  "exitCodes": [
+                    1
+                  ]
+                },
+                {
+                  "action": "runShell",
+                  "command": "echo",
+                  "args": [
+                    "setup"
+                  ],
+                  "exitCodes": [
+                    0
+                  ],
+                  "output": "/.*?/",
+                  "setVariables": [
+                    {
+                      "name": "TEST",
+                      "regex": ".*"
+                    }
+                  ]
                 }
               ]
             },

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -189,7 +189,7 @@
           "detectSteps": {
             "type": "boolean",
             "description": "Whether or not to detect steps in input files based on markup regex.",
-            "default": true
+            "default": false
           },
           "mediaDirectory": {
             "description": "Path of the directory in which to store output media files.",
@@ -602,6 +602,7 @@
             "name": "Markdown",
             "extensions": [
               ".md",
+              ".markdown",
               ".mdx"
             ],
             "testStartStatementOpen": "[comment]: # (test start",
@@ -610,141 +611,21 @@
             "testEndStatement": "[comment]: # (test end)",
             "stepStatementOpen": "[comment]: # (step",
             "stepStatementClose": ")",
-            "markup": [
-              {
-                "name": "onscreenText",
-                "regex": [
-                  "\\*\\*.+?\\*\\*"
-                ],
-                "actions": [
-                  "find"
-                ]
-              },
-              {
-                "name": "emphasis",
-                "regex": [
-                  "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
-                ],
-                "actions": [
-                  "find"
-                ]
-              },
-              {
-                "name": "image",
-                "regex": [
-                  "!\\[.+?\\]\\(.+?\\)"
-                ],
-                "actions": [
-                  "checkLink"
-                ]
-              },
-              {
-                "name": "hyperlink",
-                "regex": [
-                  "(?<!!)\\[.+?\\]\\(.+?\\)"
-                ],
-                "actions": [
-                  "checkLink",
-                  "goTo",
-                  "httpRequest"
-                ]
-              },
-              {
-                "name": "orderedList",
-                "regex": [
-                  "(?<=\n) *?[0-9][0-9]?[0-9]?.\\s*.*"
-                ]
-              },
-              {
-                "name": "unorderedList",
-                "regex": [
-                  "(?<=\n) *?\\*.\\s*.*",
-                  "(?<=\n) *?-.\\s*.*"
-                ]
-              },
-              {
-                "name": "codeInline",
-                "regex": [
-                  "(?<!`)`(?!`).+?(?<!`)`(?!`)"
-                ],
-                "actions": [
-                  "runShell",
-                  "setVariables",
-                  "httpRequest"
-                ]
-              },
-              {
-                "name": "codeBlock",
-                "regex": [
-                  "(?=(```))(\\w|\\W)*(?<=```)"
-                ],
-                "actions": [
-                  "runShell",
-                  "setVariables",
-                  "httpRequest"
-                ]
-              },
-              {
-                "name": "interaction",
-                "regex": [
-                  "[cC]lick",
-                  "[tT]ap",
-                  "[tT]ouch",
-                  "[sS]elect",
-                  "[cC]hoose",
-                  "[tT]oggle",
-                  "[eE]nable",
-                  "[dD]isable",
-                  "[tT]urn [oO][ff|n]",
-                  "[tT]ype",
-                  "[eE]nter",
-                  "[sS]end",
-                  "[aA]dd",
-                  "[rR]emove",
-                  "[dD]elete",
-                  "[uU]pload",
-                  "[dD]ownload",
-                  "[sS]croll",
-                  "[sS]earch",
-                  "[fF]ilter",
-                  "[sS]ort",
-                  "[cC]opy",
-                  "[pP]aste",
-                  "[cC]ut",
-                  "[rR]eplace",
-                  "[cC]lear",
-                  "[rR]efresh",
-                  "[rR]evert",
-                  "[rR]estore",
-                  "[rR]eset",
-                  "[lL]ogin",
-                  "[lL]ogout",
-                  "[sS]ign [iI]n",
-                  "[sS]ign [oO]ut",
-                  "[sS]ubmit",
-                  "[cC]ancel",
-                  "[cC]lose",
-                  "[aA]ccept",
-                  "[dD]ecline",
-                  "[dD]eny",
-                  "[rR]eject",
-                  "[rR]etry",
-                  "[rR]estart",
-                  "[rR]esume"
-                ],
-                "actions": [
-                  "checkLink",
-                  "find",
-                  "goTo",
-                  "httpRequest",
-                  "runShell",
-                  "saveScreenshot",
-                  "setVariables",
-                  "typeKeys",
-                  "wait"
-                ]
-              }
-            ]
+            "markup": []
+          },
+          {
+            "name": "AsciiDoc",
+            "extensions": [
+              ".adoc",
+              ".asciidoc, .asc"
+            ],
+            "testStartStatementOpen": "// (test start",
+            "testStartStatementClose": ")",
+            "testIgnoreStatement": "// (test ignore)",
+            "testEndStatement": "// (test end)",
+            "stepStatementOpen": "// (step",
+            "stepStatementClose": ")",
+            "markup": []
           }
         ]
       },

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -626,6 +626,22 @@
             "stepStatementOpen": "// (step",
             "stepStatementClose": ")",
             "markup": []
+          },
+          {
+            "name": "HTML/XML",
+            "extensions": [
+              ".html",
+              ".htm",
+              ".xml",
+              ".xhtml"
+            ],
+            "testStartStatementOpen": "<!-- test start",
+            "testStartStatementClose": "-->",
+            "testIgnoreStatement": "<!-- test ignore -->",
+            "testEndStatement": "<!-- test end -->",
+            "stepStatementOpen": "<!-- step",
+            "stepStatementClose": "-->",
+            "markup": []
           }
         ]
       },

--- a/src/schemas/src_schemas/config_v2.schema.json
+++ b/src/schemas/src_schemas/config_v2.schema.json
@@ -331,6 +331,17 @@
           "stepStatementOpen": "// (step",
           "stepStatementClose": ")",
           "markup": []
+        },
+        {
+          "name": "HTML/XML",
+          "extensions": [".html", ".htm", ".xml", ".xhtml"],
+          "testStartStatementOpen": "<!-- test start",
+          "testStartStatementClose": "-->",
+          "testIgnoreStatement": "<!-- test ignore -->",
+          "testEndStatement": "<!-- test end -->",
+          "stepStatementOpen": "<!-- step",
+          "stepStatementClose": "-->",
+          "markup": []
         }
       ]
     },

--- a/src/schemas/src_schemas/config_v2.schema.json
+++ b/src/schemas/src_schemas/config_v2.schema.json
@@ -319,7 +319,106 @@
           "testEndStatement": "[comment]: # (test end)",
           "stepStatementOpen": "[comment]: # (step",
           "stepStatementClose": ")",
-          "markup": []
+          "markup": [
+            {
+              "name": "onscreenText",
+              "regex": ["\\*\\*.+?\\*\\*"],
+              "actions": ["find"]
+            },
+            {
+              "name": "emphasis",
+              "regex": ["(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"],
+              "actions": ["find"]
+            },
+            {
+              "name": "image",
+              "regex": ["!\\[.+?\\]\\(.+?\\)"],
+              "actions": ["checkLink"]
+            },
+            {
+              "name": "hyperlink",
+              "regex": ["(?<!!)\\[.+?\\]\\(.+?\\)"],
+              "actions": ["checkLink", "goTo", "httpRequest"]
+            },
+            {
+              "name": "orderedList",
+              "regex": ["(?<=\n) *?[0-9][0-9]?[0-9]?.\\s*.*"]
+            },
+            {
+              "name": "unorderedList",
+              "regex": ["(?<=\n) *?\\*.\\s*.*", "(?<=\n) *?-.\\s*.*"]
+            },
+            {
+              "name": "codeInline",
+              "regex": ["(?<!`)`(?!`).+?(?<!`)`(?!`)"],
+              "actions": ["runShell", "setVariables", "httpRequest"]
+            },
+            {
+              "name": "codeBlock",
+              "regex": ["(?=(```))(\\w|\\W)*(?<=```)"],
+              "actions": ["runShell", "setVariables", "httpRequest"]
+            },
+            {
+              "name": "interaction",
+              "regex": [
+                "[cC]lick",
+                "[tT]ap",
+                "[tT]ouch",
+                "[sS]elect",
+                "[cC]hoose",
+                "[tT]oggle",
+                "[eE]nable",
+                "[dD]isable",
+                "[tT]urn [oO][ff|n]",
+                "[tT]ype",
+                "[eE]nter",
+                "[sS]end",
+                "[aA]dd",
+                "[rR]emove",
+                "[dD]elete",
+                "[uU]pload",
+                "[dD]ownload",
+                "[sS]croll",
+                "[sS]earch",
+                "[fF]ilter",
+                "[sS]ort",
+                "[cC]opy",
+                "[pP]aste",
+                "[cC]ut",
+                "[rR]eplace",
+                "[cC]lear",
+                "[rR]efresh",
+                "[rR]evert",
+                "[rR]estore",
+                "[rR]eset",
+                "[lL]ogin",
+                "[lL]ogout",
+                "[sS]ign [iI]n",
+                "[sS]ign [oO]ut",
+                "[sS]ubmit",
+                "[cC]ancel",
+                "[cC]lose",
+                "[aA]ccept",
+                "[dD]ecline",
+                "[dD]eny",
+                "[rR]eject",
+                "[rR]etry",
+                "[rR]estart",
+                "[rR]esume"
+              ],
+              "actions": [
+                "checkLink",
+                "find",
+                "goTo",
+                "httpRequest",
+                "runShell",
+                "saveScreenshot",
+                "setVariables",
+                "typeKeys",
+                "wait"
+              ]
+            }
+          ]
         },
         {
           "name": "AsciiDoc",

--- a/src/schemas/src_schemas/config_v2.schema.json
+++ b/src/schemas/src_schemas/config_v2.schema.json
@@ -73,7 +73,7 @@
         "detectSteps": {
           "type": "boolean",
           "description": "Whether or not to detect steps in input files based on markup regex.",
-          "default": true
+          "default": false
         },
         "mediaDirectory": {
           "description": "Path of the directory in which to store output media files.",
@@ -312,113 +312,25 @@
       "default": [
         {
           "name": "Markdown",
-          "extensions": [".md", ".mdx"],
+          "extensions": [".md", ".markdown", ".mdx"],
           "testStartStatementOpen": "[comment]: # (test start",
           "testStartStatementClose": ")",
           "testIgnoreStatement": "[comment]: # (test ignore)",
           "testEndStatement": "[comment]: # (test end)",
           "stepStatementOpen": "[comment]: # (step",
           "stepStatementClose": ")",
-          "markup": [
-            {
-              "name": "onscreenText",
-              "regex": ["\\*\\*.+?\\*\\*"],
-              "actions": ["find"]
-            },
-            {
-              "name": "emphasis",
-              "regex": ["(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"],
-              "actions": ["find"]
-            },
-            {
-              "name": "image",
-              "regex": ["!\\[.+?\\]\\(.+?\\)"],
-              "actions": ["checkLink"]
-            },
-            {
-              "name": "hyperlink",
-              "regex": ["(?<!!)\\[.+?\\]\\(.+?\\)"],
-              "actions": ["checkLink", "goTo", "httpRequest"]
-            },
-            {
-              "name": "orderedList",
-              "regex": ["(?<=\n) *?[0-9][0-9]?[0-9]?.\\s*.*"]
-            },
-            {
-              "name": "unorderedList",
-              "regex": ["(?<=\n) *?\\*.\\s*.*", "(?<=\n) *?-.\\s*.*"]
-            },
-            {
-              "name": "codeInline",
-              "regex": ["(?<!`)`(?!`).+?(?<!`)`(?!`)"],
-              "actions": ["runShell", "setVariables", "httpRequest"]
-            },
-            {
-              "name": "codeBlock",
-              "regex": ["(?=(```))(\\w|\\W)*(?<=```)"],
-              "actions": ["runShell", "setVariables", "httpRequest"]
-            },
-            {
-              "name": "interaction",
-              "regex": [
-                "[cC]lick",
-                "[tT]ap",
-                "[tT]ouch",
-                "[sS]elect",
-                "[cC]hoose",
-                "[tT]oggle",
-                "[eE]nable",
-                "[dD]isable",
-                "[tT]urn [oO][ff|n]",
-                "[tT]ype",
-                "[eE]nter",
-                "[sS]end",
-                "[aA]dd",
-                "[rR]emove",
-                "[dD]elete",
-                "[uU]pload",
-                "[dD]ownload",
-                "[sS]croll",
-                "[sS]earch",
-                "[fF]ilter",
-                "[sS]ort",
-                "[cC]opy",
-                "[pP]aste",
-                "[cC]ut",
-                "[rR]eplace",
-                "[cC]lear",
-                "[rR]efresh",
-                "[rR]evert",
-                "[rR]estore",
-                "[rR]eset",
-                "[lL]ogin",
-                "[lL]ogout",
-                "[sS]ign [iI]n",
-                "[sS]ign [oO]ut",
-                "[sS]ubmit",
-                "[cC]ancel",
-                "[cC]lose",
-                "[aA]ccept",
-                "[dD]ecline",
-                "[dD]eny",
-                "[rR]eject",
-                "[rR]etry",
-                "[rR]estart",
-                "[rR]esume"
-              ],
-              "actions": [
-                "checkLink",
-                "find",
-                "goTo",
-                "httpRequest",
-                "runShell",
-                "saveScreenshot",
-                "setVariables",
-                "typeKeys",
-                "wait"
-              ]
-            }
-          ]
+          "markup": []
+        },
+        {
+          "name": "AsciiDoc",
+          "extensions": [".adoc", ".asciidoc, .asc"],
+          "testStartStatementOpen": "// (test start",
+          "testStartStatementClose": ")",
+          "testIgnoreStatement": "// (test ignore)",
+          "testEndStatement": "// (test end)",
+          "stepStatementOpen": "// (step",
+          "stepStatementClose": ")",
+          "markup": []
         }
       ]
     },
@@ -573,13 +485,15 @@
             {
               "name": "onscreenText",
               "regex": ["\\*\\*.+?\\*\\*"],
-              "actions": [{
-                "name": "find",
-                "params": {
-                  "moveTo": true,
-                  "click": true
+              "actions": [
+                {
+                  "name": "find",
+                  "params": {
+                    "moveTo": true,
+                    "click": true
+                  }
                 }
-              }]
+              ]
             },
             {
               "name": "emphasis",

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -31,6 +31,46 @@
         ]
       },
       "default": []
+    },
+    "exitCodes": {
+      "type": "array",
+      "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+      "items": {
+        "oneOf": [
+          {
+            "type": "integer"
+          }
+        ]
+      },
+      "default": [0]
+    },
+    "output": {
+      "type": "string",
+      "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+    },
+    "setVariables": {
+      "type": "array",
+      "description": "Extract environment variables from the command's output.",
+      "items": {
+        "oneOf": [
+          {
+            "description": "",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable to set.",
+                "type": "string"
+              },
+              "regex": {
+                "description": "Regex to extract the environment variable from the command's output.",
+                "type": "string"
+              }
+            },
+            "required": ["name", "regex"]
+          }
+        ]
+      },
+      "default": []
     }
   },
   "dynamicDefaults": {
@@ -50,6 +90,30 @@
       "args": ["hello-world"],
       "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
       "description": "This is a test!"
+    },
+    {
+      "action": "runShell",
+      "command": "docker run hello-world",
+      "exitCodes": [0],
+      "output": "Hello from Docker!"
+    },
+    {
+      "action": "runShell",
+      "command": "false",
+      "exitCodes": [1]
+    },
+    {
+      "action": "runShell",
+      "command": "echo",
+      "args": ["setup"],
+      "exitCodes": [0],
+      "output": "/.*?/",
+      "setVariables": [
+        {
+          "name": "TEST",
+          "regex": ".*"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Adds default test and step statements for AsciiDoc, HTML, and XML.
- Adds the `exitCodes`, `output`, and `setVariables` fields to `runShell`. These fields allow for more control and customization when running commands and extracting information from their output.