### PR TITLE
Capture group support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.0",
+  "version": "1.16.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.16.0",
+      "version": "1.16.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "doc-detective-common",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.5.4",
-        "ajv": "^8.12.0",
+        "@apidevtools/json-schema-ref-parser": "^11.6.1",
+        "ajv": "^8.13.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^3.0.1",
         "ajv-keywords": "^5.1.0",
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.5.4",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.5.4.tgz",
-      "integrity": "sha512-o2fsypTGU0WxRxbax8zQoHiIB4dyrkwYfcm8TxZ+bx9pCzcWZbQtiMqpgBvWA/nJ2TrGjK5adCLfTH8wUeU/Wg==",
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.1.tgz",
+      "integrity": "sha512-DxjgKBCoyReu4p5HMvpmgSOfRhhBcuf5V5soDDRgOTZMwsA4KSFzol1abFZgiCTE11L2kKGca5Md9GwDdXVBwQ==",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.15",
@@ -1177,14 +1177,14 @@
       "dev": true
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "uri-js": "^4.4.1"
       },
       "funding": {
         "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.0-rc.0",
+  "version": "1.16.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.16.0-rc.0",
+      "version": "1.16.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.1",
-        "ajv": "^8.13.0",
+        "ajv": "8.12.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^3.0.1",
         "ajv-keywords": "^5.1.0",
@@ -1177,14 +1177,14 @@
       "dev": true
     },
     "node_modules/ajv": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
+        "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.0-rc.1",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.16.0-rc.1",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {
@@ -22,8 +22,8 @@
     "jest": "^29.7.0"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^11.5.4",
-    "ajv": "^8.12.0",
+    "@apidevtools/json-schema-ref-parser": "^11.6.1",
+    "ajv": "^8.13.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",
     "ajv-keywords": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.0-rc.1",
+  "version": "1.16.0",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.0",
+  "version": "1.16.0-rc.0",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.0-rc.0",
+  "version": "1.16.0-rc.1",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.6.1",
-    "ajv": "^8.13.0",
+    "ajv": "8.12.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",
     "ajv-keywords": "^5.1.0",

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -465,6 +465,8 @@
                                   "runShell",
                                   "saveScreenshot",
                                   "setVariables",
+                                  "startRecording",
+                                  "stopRecording",
                                   "typeKeys",
                                   "wait"
                                 ]
@@ -472,6 +474,7 @@
                               {
                                 "type": "object",
                                 "additionalProperties": false,
+                                "deprecated": true,
                                 "properties": {
                                   "name": {
                                     "description": "Name of the action.",
@@ -484,6 +487,8 @@
                                       "runShell",
                                       "saveScreenshot",
                                       "setVariables",
+                                      "startRecording",
+                                      "stopRecording",
                                       "typeKeys",
                                       "wait"
                                     ]
@@ -496,6 +501,909 @@
                                 },
                                 "required": [
                                   "name"
+                                ]
+                              },
+                              {
+                                "title": "checkLink",
+                                "type": "object",
+                                "description": "Check if a URL returns an acceptable status code from a GET request.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the step."
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Description of the step."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "const": "checkLink",
+                                    "description": "Action to perform."
+                                  },
+                                  "url": {
+                                    "type": "string",
+                                    "description": "URL to check.",
+                                    "pattern": "(^(http://|https://|/).*|\\$[A-Za-z0-9_]+)",
+                                    "transform": [
+                                      "trim"
+                                    ]
+                                  },
+                                  "origin": {
+                                    "type": "string",
+                                    "description": "Protocol and domain to navigate to. Prepended to `url`.",
+                                    "transform": [
+                                      "trim"
+                                    ]
+                                  },
+                                  "statusCodes": {
+                                    "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
+                                    "type": "array",
+                                    "items": {
+                                      "oneOf": [
+                                        {
+                                          "type": "integer"
+                                        }
+                                      ]
+                                    },
+                                    "default": [
+                                      200,
+                                      201,
+                                      202
+                                    ]
+                                  }
+                                },
+                                "dynamicDefaults": {
+                                  "id": "uuid"
+                                },
+                                "required": [
+                                  "action",
+                                  "url"
+                                ],
+                                "additionalProperties": false,
+                                "examples": [
+                                  {
+                                    "action": "checkLink",
+                                    "url": "https://www.google.com"
+                                  },
+                                  {
+                                    "action": "checkLink",
+                                    "url": "https://www.google.com",
+                                    "statusCodes": [
+                                      200
+                                    ]
+                                  },
+                                  {
+                                    "action": "checkLink",
+                                    "url": "/search",
+                                    "origin": "www.google.com",
+                                    "statusCodes": [
+                                      200
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "title": "find",
+                                "type": "object",
+                                "description": "Check if an element exists with the specified CSS selector.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the step."
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Description of the step."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "const": "find",
+                                    "description": "Action to perform."
+                                  },
+                                  "selector": {
+                                    "description": "Selector that uniquely identifies the element.",
+                                    "type": "string"
+                                  },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max duration in milliseconds to wait for the element to exist.",
+                                    "default": 5000
+                                  },
+                                  "matchText": {
+                                    "type": "string",
+                                    "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                                  },
+                                  "moveTo": {
+                                    "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
+                                    "oneOf": [
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "default": false
+                                  },
+                                  "click": {
+                                    "type": "boolean",
+                                    "description": "Click the element.",
+                                    "default": false
+                                  },
+                                  "typeKeys": {
+                                    "description": "Type keys after finding the element. Either a string or an object with a `keys` field as defined in [`typeKeys`](/reference/schemas/typeKeys).<br><br>To type in the element, make the element active with the `click` parameter.",
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "keys": {
+                                            "description": "String of keys to enter.",
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "delay": {
+                                            "type": "number",
+                                            "description": "Delay in milliseconds between each key press. Only valid during a recording.",
+                                            "default": 100
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "action",
+                                  "selector"
+                                ],
+                                "dynamicDefaults": {
+                                  "id": "uuid"
+                                },
+                                "additionalProperties": false,
+                                "examples": [
+                                  {
+                                    "action": "find",
+                                    "selector": "[title=Search]"
+                                  },
+                                  {
+                                    "action": "find",
+                                    "selector": "[title=Search]",
+                                    "timeout": 10000,
+                                    "matchText": "Search",
+                                    "moveTo": true,
+                                    "click": true,
+                                    "typeKeys": "shorthair cat"
+                                  },
+                                  {
+                                    "action": "find",
+                                    "selector": "[title=Search]",
+                                    "timeout": 10000,
+                                    "matchText": "Search",
+                                    "moveTo": true,
+                                    "click": true,
+                                    "typeKeys": {
+                                      "keys": [
+                                        "shorthair cat"
+                                      ],
+                                      "delay": 100
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "title": "goTo",
+                                "type": "object",
+                                "description": "Navigate to a specified URL.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the step."
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Description of the step."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "const": "goTo",
+                                    "description": "Action to perform."
+                                  },
+                                  "url": {
+                                    "type": "string",
+                                    "description": "URL to navigate to.",
+                                    "pattern": "(^(http://|https://|/).*|\\$[A-Za-z0-9_]+)",
+                                    "transform": [
+                                      "trim"
+                                    ]
+                                  },
+                                  "origin": {
+                                    "type": "string",
+                                    "description": "Protocol and domain to navigate to. Prepended to `url`.",
+                                    "transform": [
+                                      "trim"
+                                    ]
+                                  }
+                                },
+                                "dynamicDefaults": {
+                                  "id": "uuid"
+                                },
+                                "required": [
+                                  "action",
+                                  "url"
+                                ],
+                                "additionalProperties": false,
+                                "examples": [
+                                  {
+                                    "action": "goTo",
+                                    "url": "https://www.google.com"
+                                  },
+                                  {
+                                    "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
+                                    "description": "This is a test!",
+                                    "action": "goTo",
+                                    "url": "https://www.google.com"
+                                  },
+                                  {
+                                    "id": "ddec5e20-2e81-4f38-867c-92c8d9516756",
+                                    "description": "This is a test!",
+                                    "action": "goTo",
+                                    "url": "/search",
+                                    "origin": "https://www.google.com"
+                                  }
+                                ]
+                              },
+                              {
+                                "title": "httpRequest",
+                                "type": "object",
+                                "description": "Perform a generic HTTP request, for example to an API.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the step."
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Description of the step."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "const": "httpRequest",
+                                    "description": "Aciton to perform."
+                                  },
+                                  "url": {
+                                    "type": "string",
+                                    "description": "URL for the HTTP request.",
+                                    "pattern": "(^(http://|https://).*|\\$[A-Za-z0-9_]+)",
+                                    "transform": [
+                                      "trim"
+                                    ]
+                                  },
+                                  "statusCodes": {
+                                    "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
+                                    "type": "array",
+                                    "items": {
+                                      "oneOf": [
+                                        {
+                                          "type": "integer"
+                                        }
+                                      ]
+                                    },
+                                    "default": [
+                                      200
+                                    ]
+                                  },
+                                  "method": {
+                                    "type": "string",
+                                    "description": "Method of the HTTP request",
+                                    "enum": [
+                                      "get",
+                                      "put",
+                                      "post",
+                                      "patch",
+                                      "delete"
+                                    ],
+                                    "transform": [
+                                      "trim",
+                                      "toEnumCase"
+                                    ],
+                                    "default": "get"
+                                  },
+                                  "requestHeaders": {
+                                    "description": "Headers to include in the HTTP request, in key/value format.",
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "properties": {},
+                                    "default": {}
+                                  },
+                                  "responseHeaders": {
+                                    "description": "Headers expected in the response, in key/value format. If one or more `responseHeaders` entries aren't present in the response, the step fails.",
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "properties": {},
+                                    "default": {}
+                                  },
+                                  "requestParams": {
+                                    "description": "URL parameters to include in the HTTP request, in key/value format.",
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "default": {},
+                                    "properties": {}
+                                  },
+                                  "responseParams": {
+                                    "description": "URL parameters expected in the response, in key/value format. If one or more `responseParams` entries aren't present in the response, the step fails.",
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "default": {},
+                                    "properties": {}
+                                  },
+                                  "requestData": {
+                                    "description": "JSON object to include as the body of the HTTP request.",
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "default": {},
+                                    "properties": {}
+                                  },
+                                  "responseData": {
+                                    "description": "JSON object expected in the response. If one or more key/value pairs aren't present in the response, the step fails.",
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "default": {},
+                                    "properties": {}
+                                  },
+                                  "envsFromResponseData": {
+                                    "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
+                                    "type": "array",
+                                    "default": [],
+                                    "items": {
+                                      "oneOf": [
+                                        {
+                                          "description": "",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the environment variable to set.",
+                                              "type": "string"
+                                            },
+                                            "jqFilter": {
+                                              "description": "jq filter to apply to the response data. If the filter doesn't return a value, the environment variable isn't set.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "jqFilter"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                "dynamicDefaults": {
+                                  "id": "uuid"
+                                },
+                                "required": [
+                                  "action",
+                                  "url"
+                                ],
+                                "additionalProperties": false,
+                                "examples": [
+                                  {
+                                    "action": "httpRequest",
+                                    "url": "https://reqres.in/api/users"
+                                  },
+                                  {
+                                    "action": "httpRequest",
+                                    "url": "https://reqres.in/api/users/2",
+                                    "method": "put",
+                                    "requestData": {
+                                      "name": "morpheus",
+                                      "job": "zion resident"
+                                    }
+                                  },
+                                  {
+                                    "action": "httpRequest",
+                                    "url": "https://reqres.in/api/users",
+                                    "method": "post",
+                                    "requestData": {
+                                      "name": "morpheus",
+                                      "job": "leader"
+                                    },
+                                    "responseData": {
+                                      "name": "morpheus",
+                                      "job": "leader"
+                                    },
+                                    "statusCodes": [
+                                      200,
+                                      201
+                                    ]
+                                  },
+                                  {
+                                    "action": "httpRequest",
+                                    "url": "https://www.api-server.com",
+                                    "method": "post",
+                                    "requestHeaders": {
+                                      "header": "value"
+                                    },
+                                    "requestParams": {
+                                      "param": "value"
+                                    },
+                                    "requestData": {
+                                      "field": "value"
+                                    },
+                                    "responseHeaders": {
+                                      "header": "value"
+                                    },
+                                    "responseData": {
+                                      "field": "value"
+                                    },
+                                    "statusCodes": [
+                                      200
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "title": "runShell",
+                                "type": "object",
+                                "description": "Perform a native shell command.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the step."
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Description of the step."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "const": "runShell",
+                                    "description": "The action to perform."
+                                  },
+                                  "command": {
+                                    "type": "string",
+                                    "description": "Command to perform in the machine's default shell."
+                                  },
+                                  "args": {
+                                    "type": "array",
+                                    "description": "Arguments for the command.",
+                                    "items": {
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "default": []
+                                  },
+                                  "exitCodes": {
+                                    "type": "array",
+                                    "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+                                    "items": {
+                                      "oneOf": [
+                                        {
+                                          "type": "integer"
+                                        }
+                                      ]
+                                    },
+                                    "default": [
+                                      0
+                                    ]
+                                  },
+                                  "output": {
+                                    "type": "string",
+                                    "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                                  },
+                                  "setVariables": {
+                                    "type": "array",
+                                    "description": "Extract environment variables from the command's output.",
+                                    "items": {
+                                      "oneOf": [
+                                        {
+                                          "description": "",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the environment variable to set.",
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "description": "Regex to extract the environment variable from the command's output.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "regex"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "default": []
+                                  }
+                                },
+                                "dynamicDefaults": {
+                                  "id": "uuid"
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "action",
+                                  "command"
+                                ],
+                                "examples": [
+                                  {
+                                    "action": "runShell",
+                                    "command": "echo",
+                                    "args": [
+                                      "$USER"
+                                    ]
+                                  },
+                                  {
+                                    "action": "runShell",
+                                    "command": "echo",
+                                    "args": [
+                                      "hello-world"
+                                    ],
+                                    "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
+                                    "description": "This is a test!"
+                                  },
+                                  {
+                                    "action": "runShell",
+                                    "command": "docker run hello-world",
+                                    "exitCodes": [
+                                      0
+                                    ],
+                                    "output": "Hello from Docker!"
+                                  },
+                                  {
+                                    "action": "runShell",
+                                    "command": "false",
+                                    "exitCodes": [
+                                      1
+                                    ]
+                                  },
+                                  {
+                                    "action": "runShell",
+                                    "command": "echo",
+                                    "args": [
+                                      "setup"
+                                    ],
+                                    "exitCodes": [
+                                      0
+                                    ],
+                                    "output": "/.*?/",
+                                    "setVariables": [
+                                      {
+                                        "name": "TEST",
+                                        "regex": ".*"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "title": "saveScreenshot",
+                                "type": "object",
+                                "description": "Takes a screenshot in PNG format.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the step."
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Description of the step."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "const": "saveScreenshot",
+                                    "description": "The action to perform."
+                                  },
+                                  "path": {
+                                    "type": "string",
+                                    "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                                    "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
+                                  },
+                                  "directory": {
+                                    "type": "string",
+                                    "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                                  },
+                                  "maxVariation": {
+                                    "type": "number",
+                                    "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                                    "minimum": 0,
+                                    "maximum": 100
+                                  },
+                                  "overwrite": {
+                                    "type": "string",
+                                    "description": "If `true`, overwrites the existing screenshot at `path` if it exists.\nIf `byVariation`, overwrites the existing screenshot at `path` if the difference between the new screenshot and the existing screenshot is greater than `maxVariation`.",
+                                    "enum": [
+                                      "true",
+                                      "false",
+                                      "byVariation"
+                                    ],
+                                    "default": false
+                                  }
+                                },
+                                "dynamicDefaults": {
+                                  "id": "uuid"
+                                },
+                                "required": [
+                                  "action"
+                                ],
+                                "additionalProperties": false,
+                                "examples": [
+                                  {
+                                    "action": "saveScreenshot"
+                                  },
+                                  {
+                                    "action": "saveScreenshot",
+                                    "path": "results.png"
+                                  },
+                                  {
+                                    "action": "saveScreenshot",
+                                    "path": "results.png",
+                                    "directory": "static/images"
+                                  },
+                                  {
+                                    "action": "saveScreenshot",
+                                    "path": "results.png",
+                                    "directory": "static/images",
+                                    "maxVariation": 10,
+                                    "overwrite": "byVariation"
+                                  }
+                                ]
+                              },
+                              {
+                                "title": "setVariables",
+                                "type": "object",
+                                "description": "Load environment variables from a `.env` file.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the step."
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Description of the step."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "const": "setVariables",
+                                    "description": "Action to perform."
+                                  },
+                                  "path": {
+                                    "type": "string",
+                                    "description": "Path to the `.env` file."
+                                  }
+                                },
+                                "dynamicDefaults": {
+                                  "id": "uuid"
+                                },
+                                "required": [
+                                  "action",
+                                  "path"
+                                ],
+                                "additionalProperties": false,
+                                "examples": [
+                                  {
+                                    "action": "setVariables",
+                                    "path": ".env"
+                                  }
+                                ]
+                              },
+                              {
+                                "title": "startRecording",
+                                "type": "object",
+                                "description": "Start recording the current browser viewport. Must be followed by a `stopRecording` action. Only runs when the context `app` is `chrome` and `headless` is `false`. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the step."
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Description of the step."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "const": "startRecording",
+                                    "description": "The action to perform."
+                                  },
+                                  "path": {
+                                    "type": "string",
+                                    "description": "File path of the recording. Supports the `.mp4`, `.webm`, and `.gif` extensions. If not specified, the file path is your media directory, the file name is the ID of the step, and the extension is `.mp4`.",
+                                    "pattern": "([A-Za-z0-9_-]*\\.(mp4|webm|gif)$|\\$[A-Za-z0-9_]+)"
+                                  },
+                                  "directory": {
+                                    "type": "string",
+                                    "description": "Directory of the file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                                  },
+                                  "overwrite": {
+                                    "type": "boolean",
+                                    "description": "If `true`, overwrites the existing file at `path` if it exists.",
+                                    "default": false
+                                  }
+                                },
+                                "dynamicDefaults": {
+                                  "id": "uuid"
+                                },
+                                "required": [
+                                  "action"
+                                ],
+                                "additionalProperties": false,
+                                "examples": [
+                                  {
+                                    "action": "startRecording"
+                                  },
+                                  {
+                                    "action": "startRecording",
+                                    "path": "results.mp4"
+                                  },
+                                  {
+                                    "action": "startRecording",
+                                    "path": "results.mp4",
+                                    "directory": "static/media",
+                                    "overwrite": true
+                                  }
+                                ]
+                              },
+                              {
+                                "title": "stopRecording",
+                                "type": "object",
+                                "description": "Stop the current recording.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the step."
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Description of the step."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "const": "stopRecording",
+                                    "description": "The action to perform."
+                                  }
+                                },
+                                "dynamicDefaults": {
+                                  "id": "uuid"
+                                },
+                                "required": [
+                                  "action"
+                                ],
+                                "additionalProperties": false,
+                                "examples": [
+                                  {
+                                    "action": "stopRecording"
+                                  }
+                                ]
+                              },
+                              {
+                                "title": "typeKeys",
+                                "type": "object",
+                                "description": "Type keys. To type special keys, begin and end the string with `$` and use the [special key's enum](). For example, to type the Escape key, enter `$ESCAPE$`.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the step."
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Description of the step."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "const": "typeKeys",
+                                    "description": "The action to perform."
+                                  },
+                                  "keys": {
+                                    "description": "String of keys to enter.",
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "oneOf": [
+                                            {
+                                              "type": "string"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "delay": {
+                                    "type": "number",
+                                    "description": "Delay in milliseconds between each key press. Only valid during a recording.",
+                                    "default": 100
+                                  }
+                                },
+                                "dynamicDefaults": {
+                                  "id": "uuid"
+                                },
+                                "required": [
+                                  "action",
+                                  "keys"
+                                ],
+                                "additionalProperties": false,
+                                "examples": [
+                                  {
+                                    "action": "typeKeys",
+                                    "keys": "kittens"
+                                  },
+                                  {
+                                    "action": "typeKeys",
+                                    "keys": [
+                                      "$ENTER$"
+                                    ]
+                                  },
+                                  {
+                                    "action": "typeKeys",
+                                    "keys": [
+                                      "kittens",
+                                      "$ENTER$"
+                                    ],
+                                    "delay": 500
+                                  }
+                                ]
+                              },
+                              {
+                                "title": "wait",
+                                "type": "object",
+                                "description": "Pause before performing the next action.",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "ID of the step."
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Description of the step."
+                                  },
+                                  "action": {
+                                    "type": "string",
+                                    "const": "wait",
+                                    "description": "The action to perform."
+                                  },
+                                  "duration": {
+                                    "type": "number",
+                                    "description": "Milliseconds to wait.",
+                                    "default": 5000
+                                  }
+                                },
+                                "dynamicDefaults": {
+                                  "id": "uuid"
+                                },
+                                "required": [
+                                  "action"
+                                ],
+                                "additionalProperties": false,
+                                "examples": [
+                                  {
+                                    "action": "wait"
+                                  },
+                                  {
+                                    "action": "wait",
+                                    "duration": 5000
+                                  }
                                 ]
                               }
                             ]
@@ -552,9 +1460,6 @@
               "name": "emphasis",
               "regex": [
                 "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
-              ],
-              "actions": [
-                "find"
               ]
             },
             {
@@ -572,9 +1477,16 @@
                 "(?<!!)\\[.+?\\]\\(.+?\\)"
               ],
               "actions": [
-                "checkLink",
-                "goTo",
-                "httpRequest"
+                "checkLink"
+              ]
+            },
+            {
+              "name": "navigationLink",
+              "regex": [
+                "(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"
+              ],
+              "actions": [
+                "goTo"
               ]
             },
             {
@@ -594,22 +1506,12 @@
               "name": "codeInline",
               "regex": [
                 "(?<!`)`(?!`).+?(?<!`)`(?!`)"
-              ],
-              "actions": [
-                "runShell",
-                "setVariables",
-                "httpRequest"
               ]
             },
             {
               "name": "codeBlock",
               "regex": [
                 "(?=(```))(\\w|\\W)*(?<=```)"
-              ],
-              "actions": [
-                "runShell",
-                "setVariables",
-                "httpRequest"
               ]
             },
             {
@@ -659,17 +1561,6 @@
                 "[rR]etry",
                 "[rR]estart",
                 "[rR]esume"
-              ],
-              "actions": [
-                "checkLink",
-                "find",
-                "goTo",
-                "httpRequest",
-                "runShell",
-                "saveScreenshot",
-                "setVariables",
-                "typeKeys",
-                "wait"
               ]
             }
           ]
@@ -862,6 +1753,7 @@
           "name": "Markdown",
           "extensions": [
             ".md",
+            ".markdown",
             ".mdx"
           ],
           "testStartStatementOpen": "[comment]: # (test start",
@@ -877,22 +1769,13 @@
                 "\\*\\*.+?\\*\\*"
               ],
               "actions": [
-                {
-                  "name": "find",
-                  "params": {
-                    "moveTo": true,
-                    "click": true
-                  }
-                }
+                "find"
               ]
             },
             {
               "name": "emphasis",
               "regex": [
                 "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
-              ],
-              "actions": [
-                "find"
               ]
             },
             {
@@ -910,9 +1793,16 @@
                 "(?<!!)\\[.+?\\]\\(.+?\\)"
               ],
               "actions": [
-                "checkLink",
-                "goTo",
-                "httpRequest"
+                "checkLink"
+              ]
+            },
+            {
+              "name": "navigationLink",
+              "regex": [
+                "(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"
+              ],
+              "actions": [
+                "goTo"
               ]
             },
             {
@@ -932,22 +1822,12 @@
               "name": "codeInline",
               "regex": [
                 "(?<!`)`(?!`).+?(?<!`)`(?!`)"
-              ],
-              "actions": [
-                "runShell",
-                "setVariables",
-                "httpRequest"
               ]
             },
             {
               "name": "codeBlock",
               "regex": [
                 "(?=(```))(\\w|\\W)*(?<=```)"
-              ],
-              "actions": [
-                "runShell",
-                "setVariables",
-                "httpRequest"
               ]
             },
             {
@@ -997,17 +1877,6 @@
                 "[rR]etry",
                 "[rR]estart",
                 "[rR]esume"
-              ],
-              "actions": [
-                "checkLink",
-                "find",
-                "goTo",
-                "httpRequest",
-                "runShell",
-                "saveScreenshot",
-                "setVariables",
-                "typeKeys",
-                "wait"
               ]
             }
           ]
@@ -1072,6 +1941,7 @@
           "name": "Markdown",
           "extensions": [
             ".md",
+            ".markdown",
             ".mdx"
           ],
           "testStartStatementOpen": "[comment]: # (test start",
@@ -1094,9 +1964,6 @@
               "name": "emphasis",
               "regex": [
                 "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
-              ],
-              "actions": [
-                "find"
               ]
             },
             {
@@ -1114,9 +1981,16 @@
                 "(?<!!)\\[.+?\\]\\(.+?\\)"
               ],
               "actions": [
-                "checkLink",
-                "goTo",
-                "httpRequest"
+                "checkLink"
+              ]
+            },
+            {
+              "name": "navigationLink",
+              "regex": [
+                "(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"
+              ],
+              "actions": [
+                "goTo"
               ]
             },
             {
@@ -1136,22 +2010,12 @@
               "name": "codeInline",
               "regex": [
                 "(?<!`)`(?!`).+?(?<!`)`(?!`)"
-              ],
-              "actions": [
-                "runShell",
-                "setVariables",
-                "httpRequest"
               ]
             },
             {
               "name": "codeBlock",
               "regex": [
                 "(?=(```))(\\w|\\W)*(?<=```)"
-              ],
-              "actions": [
-                "runShell",
-                "setVariables",
-                "httpRequest"
               ]
             },
             {
@@ -1201,20 +2065,39 @@
                 "[rR]etry",
                 "[rR]estart",
                 "[rR]esume"
-              ],
-              "actions": [
-                "checkLink",
-                "find",
-                "goTo",
-                "httpRequest",
-                "runShell",
-                "saveScreenshot",
-                "setVariables",
-                "typeKeys",
-                "wait"
               ]
             }
           ]
+        },
+        {
+          "name": "AsciiDoc",
+          "extensions": [
+            ".adoc",
+            ".asciidoc, .asc"
+          ],
+          "testStartStatementOpen": "// (test start",
+          "testStartStatementClose": ")",
+          "testIgnoreStatement": "// (test ignore)",
+          "testEndStatement": "// (test end)",
+          "stepStatementOpen": "// (step",
+          "stepStatementClose": ")",
+          "markup": []
+        },
+        {
+          "name": "HTML/XML",
+          "extensions": [
+            ".html",
+            ".htm",
+            ".xml",
+            ".xhtml"
+          ],
+          "testStartStatementOpen": "<!-- test start",
+          "testStartStatementClose": "-->",
+          "testIgnoreStatement": "<!-- test ignore -->",
+          "testEndStatement": "<!-- test end -->",
+          "stepStatementOpen": "<!-- step",
+          "stepStatementClose": "-->",
+          "markup": []
         }
       ],
       "integrations": {},

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -546,6 +546,8 @@
                                     "runShell",
                                     "saveScreenshot",
                                     "setVariables",
+                                    "startRecording",
+                                    "stopRecording",
                                     "typeKeys",
                                     "wait"
                                   ]
@@ -553,6 +555,7 @@
                                 {
                                   "type": "object",
                                   "additionalProperties": false,
+                                  "deprecated": true,
                                   "properties": {
                                     "name": {
                                       "description": "Name of the action.",
@@ -565,6 +568,8 @@
                                         "runShell",
                                         "saveScreenshot",
                                         "setVariables",
+                                        "startRecording",
+                                        "stopRecording",
                                         "typeKeys",
                                         "wait"
                                       ]
@@ -577,6 +582,909 @@
                                   },
                                   "required": [
                                     "name"
+                                  ]
+                                },
+                                {
+                                  "title": "checkLink",
+                                  "type": "object",
+                                  "description": "Check if a URL returns an acceptable status code from a GET request.",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "ID of the step."
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Description of the step."
+                                    },
+                                    "action": {
+                                      "type": "string",
+                                      "const": "checkLink",
+                                      "description": "Action to perform."
+                                    },
+                                    "url": {
+                                      "type": "string",
+                                      "description": "URL to check.",
+                                      "pattern": "(^(http://|https://|/).*|\\$[A-Za-z0-9_]+)",
+                                      "transform": [
+                                        "trim"
+                                      ]
+                                    },
+                                    "origin": {
+                                      "type": "string",
+                                      "description": "Protocol and domain to navigate to. Prepended to `url`.",
+                                      "transform": [
+                                        "trim"
+                                      ]
+                                    },
+                                    "statusCodes": {
+                                      "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
+                                      "type": "array",
+                                      "items": {
+                                        "oneOf": [
+                                          {
+                                            "type": "integer"
+                                          }
+                                        ]
+                                      },
+                                      "default": [
+                                        200,
+                                        201,
+                                        202
+                                      ]
+                                    }
+                                  },
+                                  "dynamicDefaults": {
+                                    "id": "uuid"
+                                  },
+                                  "required": [
+                                    "action",
+                                    "url"
+                                  ],
+                                  "additionalProperties": false,
+                                  "examples": [
+                                    {
+                                      "action": "checkLink",
+                                      "url": "https://www.google.com"
+                                    },
+                                    {
+                                      "action": "checkLink",
+                                      "url": "https://www.google.com",
+                                      "statusCodes": [
+                                        200
+                                      ]
+                                    },
+                                    {
+                                      "action": "checkLink",
+                                      "url": "/search",
+                                      "origin": "www.google.com",
+                                      "statusCodes": [
+                                        200
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "title": "find",
+                                  "type": "object",
+                                  "description": "Check if an element exists with the specified CSS selector.",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "ID of the step."
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Description of the step."
+                                    },
+                                    "action": {
+                                      "type": "string",
+                                      "const": "find",
+                                      "description": "Action to perform."
+                                    },
+                                    "selector": {
+                                      "description": "Selector that uniquely identifies the element.",
+                                      "type": "string"
+                                    },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Max duration in milliseconds to wait for the element to exist.",
+                                      "default": 5000
+                                    },
+                                    "matchText": {
+                                      "type": "string",
+                                      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                                    },
+                                    "moveTo": {
+                                      "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
+                                      "oneOf": [
+                                        {
+                                          "type": "boolean"
+                                        }
+                                      ],
+                                      "default": false
+                                    },
+                                    "click": {
+                                      "type": "boolean",
+                                      "description": "Click the element.",
+                                      "default": false
+                                    },
+                                    "typeKeys": {
+                                      "description": "Type keys after finding the element. Either a string or an object with a `keys` field as defined in [`typeKeys`](/reference/schemas/typeKeys).<br><br>To type in the element, make the element active with the `click` parameter.",
+                                      "oneOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "keys": {
+                                              "description": "String of keys to enter.",
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "delay": {
+                                              "type": "number",
+                                              "description": "Delay in milliseconds between each key press. Only valid during a recording.",
+                                              "default": 100
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "action",
+                                    "selector"
+                                  ],
+                                  "dynamicDefaults": {
+                                    "id": "uuid"
+                                  },
+                                  "additionalProperties": false,
+                                  "examples": [
+                                    {
+                                      "action": "find",
+                                      "selector": "[title=Search]"
+                                    },
+                                    {
+                                      "action": "find",
+                                      "selector": "[title=Search]",
+                                      "timeout": 10000,
+                                      "matchText": "Search",
+                                      "moveTo": true,
+                                      "click": true,
+                                      "typeKeys": "shorthair cat"
+                                    },
+                                    {
+                                      "action": "find",
+                                      "selector": "[title=Search]",
+                                      "timeout": 10000,
+                                      "matchText": "Search",
+                                      "moveTo": true,
+                                      "click": true,
+                                      "typeKeys": {
+                                        "keys": [
+                                          "shorthair cat"
+                                        ],
+                                        "delay": 100
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "title": "goTo",
+                                  "type": "object",
+                                  "description": "Navigate to a specified URL.",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "ID of the step."
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Description of the step."
+                                    },
+                                    "action": {
+                                      "type": "string",
+                                      "const": "goTo",
+                                      "description": "Action to perform."
+                                    },
+                                    "url": {
+                                      "type": "string",
+                                      "description": "URL to navigate to.",
+                                      "pattern": "(^(http://|https://|/).*|\\$[A-Za-z0-9_]+)",
+                                      "transform": [
+                                        "trim"
+                                      ]
+                                    },
+                                    "origin": {
+                                      "type": "string",
+                                      "description": "Protocol and domain to navigate to. Prepended to `url`.",
+                                      "transform": [
+                                        "trim"
+                                      ]
+                                    }
+                                  },
+                                  "dynamicDefaults": {
+                                    "id": "uuid"
+                                  },
+                                  "required": [
+                                    "action",
+                                    "url"
+                                  ],
+                                  "additionalProperties": false,
+                                  "examples": [
+                                    {
+                                      "action": "goTo",
+                                      "url": "https://www.google.com"
+                                    },
+                                    {
+                                      "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
+                                      "description": "This is a test!",
+                                      "action": "goTo",
+                                      "url": "https://www.google.com"
+                                    },
+                                    {
+                                      "id": "ddec5e20-2e81-4f38-867c-92c8d9516756",
+                                      "description": "This is a test!",
+                                      "action": "goTo",
+                                      "url": "/search",
+                                      "origin": "https://www.google.com"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "title": "httpRequest",
+                                  "type": "object",
+                                  "description": "Perform a generic HTTP request, for example to an API.",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "ID of the step."
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Description of the step."
+                                    },
+                                    "action": {
+                                      "type": "string",
+                                      "const": "httpRequest",
+                                      "description": "Aciton to perform."
+                                    },
+                                    "url": {
+                                      "type": "string",
+                                      "description": "URL for the HTTP request.",
+                                      "pattern": "(^(http://|https://).*|\\$[A-Za-z0-9_]+)",
+                                      "transform": [
+                                        "trim"
+                                      ]
+                                    },
+                                    "statusCodes": {
+                                      "description": "Accepted status codes. If the specified URL returns a code other than what is specified here, the action fails.",
+                                      "type": "array",
+                                      "items": {
+                                        "oneOf": [
+                                          {
+                                            "type": "integer"
+                                          }
+                                        ]
+                                      },
+                                      "default": [
+                                        200
+                                      ]
+                                    },
+                                    "method": {
+                                      "type": "string",
+                                      "description": "Method of the HTTP request",
+                                      "enum": [
+                                        "get",
+                                        "put",
+                                        "post",
+                                        "patch",
+                                        "delete"
+                                      ],
+                                      "transform": [
+                                        "trim",
+                                        "toEnumCase"
+                                      ],
+                                      "default": "get"
+                                    },
+                                    "requestHeaders": {
+                                      "description": "Headers to include in the HTTP request, in key/value format.",
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "properties": {},
+                                      "default": {}
+                                    },
+                                    "responseHeaders": {
+                                      "description": "Headers expected in the response, in key/value format. If one or more `responseHeaders` entries aren't present in the response, the step fails.",
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "properties": {},
+                                      "default": {}
+                                    },
+                                    "requestParams": {
+                                      "description": "URL parameters to include in the HTTP request, in key/value format.",
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "default": {},
+                                      "properties": {}
+                                    },
+                                    "responseParams": {
+                                      "description": "URL parameters expected in the response, in key/value format. If one or more `responseParams` entries aren't present in the response, the step fails.",
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "default": {},
+                                      "properties": {}
+                                    },
+                                    "requestData": {
+                                      "description": "JSON object to include as the body of the HTTP request.",
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "default": {},
+                                      "properties": {}
+                                    },
+                                    "responseData": {
+                                      "description": "JSON object expected in the response. If one or more key/value pairs aren't present in the response, the step fails.",
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "default": {},
+                                      "properties": {}
+                                    },
+                                    "envsFromResponseData": {
+                                      "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
+                                      "type": "array",
+                                      "default": [],
+                                      "items": {
+                                        "oneOf": [
+                                          {
+                                            "description": "",
+                                            "type": "object",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the environment variable to set.",
+                                                "type": "string"
+                                              },
+                                              "jqFilter": {
+                                                "description": "jq filter to apply to the response data. If the filter doesn't return a value, the environment variable isn't set.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "jqFilter"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "dynamicDefaults": {
+                                    "id": "uuid"
+                                  },
+                                  "required": [
+                                    "action",
+                                    "url"
+                                  ],
+                                  "additionalProperties": false,
+                                  "examples": [
+                                    {
+                                      "action": "httpRequest",
+                                      "url": "https://reqres.in/api/users"
+                                    },
+                                    {
+                                      "action": "httpRequest",
+                                      "url": "https://reqres.in/api/users/2",
+                                      "method": "put",
+                                      "requestData": {
+                                        "name": "morpheus",
+                                        "job": "zion resident"
+                                      }
+                                    },
+                                    {
+                                      "action": "httpRequest",
+                                      "url": "https://reqres.in/api/users",
+                                      "method": "post",
+                                      "requestData": {
+                                        "name": "morpheus",
+                                        "job": "leader"
+                                      },
+                                      "responseData": {
+                                        "name": "morpheus",
+                                        "job": "leader"
+                                      },
+                                      "statusCodes": [
+                                        200,
+                                        201
+                                      ]
+                                    },
+                                    {
+                                      "action": "httpRequest",
+                                      "url": "https://www.api-server.com",
+                                      "method": "post",
+                                      "requestHeaders": {
+                                        "header": "value"
+                                      },
+                                      "requestParams": {
+                                        "param": "value"
+                                      },
+                                      "requestData": {
+                                        "field": "value"
+                                      },
+                                      "responseHeaders": {
+                                        "header": "value"
+                                      },
+                                      "responseData": {
+                                        "field": "value"
+                                      },
+                                      "statusCodes": [
+                                        200
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "title": "runShell",
+                                  "type": "object",
+                                  "description": "Perform a native shell command.",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "ID of the step."
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Description of the step."
+                                    },
+                                    "action": {
+                                      "type": "string",
+                                      "const": "runShell",
+                                      "description": "The action to perform."
+                                    },
+                                    "command": {
+                                      "type": "string",
+                                      "description": "Command to perform in the machine's default shell."
+                                    },
+                                    "args": {
+                                      "type": "array",
+                                      "description": "Arguments for the command.",
+                                      "items": {
+                                        "oneOf": [
+                                          {
+                                            "type": "string"
+                                          }
+                                        ]
+                                      },
+                                      "default": []
+                                    },
+                                    "exitCodes": {
+                                      "type": "array",
+                                      "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
+                                      "items": {
+                                        "oneOf": [
+                                          {
+                                            "type": "integer"
+                                          }
+                                        ]
+                                      },
+                                      "default": [
+                                        0
+                                      ]
+                                    },
+                                    "output": {
+                                      "type": "string",
+                                      "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                                    },
+                                    "setVariables": {
+                                      "type": "array",
+                                      "description": "Extract environment variables from the command's output.",
+                                      "items": {
+                                        "oneOf": [
+                                          {
+                                            "description": "",
+                                            "type": "object",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the environment variable to set.",
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "description": "Regex to extract the environment variable from the command's output.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "regex"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "default": []
+                                    }
+                                  },
+                                  "dynamicDefaults": {
+                                    "id": "uuid"
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "action",
+                                    "command"
+                                  ],
+                                  "examples": [
+                                    {
+                                      "action": "runShell",
+                                      "command": "echo",
+                                      "args": [
+                                        "$USER"
+                                      ]
+                                    },
+                                    {
+                                      "action": "runShell",
+                                      "command": "echo",
+                                      "args": [
+                                        "hello-world"
+                                      ],
+                                      "id": "ddec5e20-2e81-4f38-867c-92c8d9516755",
+                                      "description": "This is a test!"
+                                    },
+                                    {
+                                      "action": "runShell",
+                                      "command": "docker run hello-world",
+                                      "exitCodes": [
+                                        0
+                                      ],
+                                      "output": "Hello from Docker!"
+                                    },
+                                    {
+                                      "action": "runShell",
+                                      "command": "false",
+                                      "exitCodes": [
+                                        1
+                                      ]
+                                    },
+                                    {
+                                      "action": "runShell",
+                                      "command": "echo",
+                                      "args": [
+                                        "setup"
+                                      ],
+                                      "exitCodes": [
+                                        0
+                                      ],
+                                      "output": "/.*?/",
+                                      "setVariables": [
+                                        {
+                                          "name": "TEST",
+                                          "regex": ".*"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "title": "saveScreenshot",
+                                  "type": "object",
+                                  "description": "Takes a screenshot in PNG format.",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "ID of the step."
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Description of the step."
+                                    },
+                                    "action": {
+                                      "type": "string",
+                                      "const": "saveScreenshot",
+                                      "description": "The action to perform."
+                                    },
+                                    "path": {
+                                      "type": "string",
+                                      "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                                      "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
+                                    },
+                                    "directory": {
+                                      "type": "string",
+                                      "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                                    },
+                                    "maxVariation": {
+                                      "type": "number",
+                                      "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                                      "minimum": 0,
+                                      "maximum": 100
+                                    },
+                                    "overwrite": {
+                                      "type": "string",
+                                      "description": "If `true`, overwrites the existing screenshot at `path` if it exists.\nIf `byVariation`, overwrites the existing screenshot at `path` if the difference between the new screenshot and the existing screenshot is greater than `maxVariation`.",
+                                      "enum": [
+                                        "true",
+                                        "false",
+                                        "byVariation"
+                                      ],
+                                      "default": false
+                                    }
+                                  },
+                                  "dynamicDefaults": {
+                                    "id": "uuid"
+                                  },
+                                  "required": [
+                                    "action"
+                                  ],
+                                  "additionalProperties": false,
+                                  "examples": [
+                                    {
+                                      "action": "saveScreenshot"
+                                    },
+                                    {
+                                      "action": "saveScreenshot",
+                                      "path": "results.png"
+                                    },
+                                    {
+                                      "action": "saveScreenshot",
+                                      "path": "results.png",
+                                      "directory": "static/images"
+                                    },
+                                    {
+                                      "action": "saveScreenshot",
+                                      "path": "results.png",
+                                      "directory": "static/images",
+                                      "maxVariation": 10,
+                                      "overwrite": "byVariation"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "title": "setVariables",
+                                  "type": "object",
+                                  "description": "Load environment variables from a `.env` file.",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "ID of the step."
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Description of the step."
+                                    },
+                                    "action": {
+                                      "type": "string",
+                                      "const": "setVariables",
+                                      "description": "Action to perform."
+                                    },
+                                    "path": {
+                                      "type": "string",
+                                      "description": "Path to the `.env` file."
+                                    }
+                                  },
+                                  "dynamicDefaults": {
+                                    "id": "uuid"
+                                  },
+                                  "required": [
+                                    "action",
+                                    "path"
+                                  ],
+                                  "additionalProperties": false,
+                                  "examples": [
+                                    {
+                                      "action": "setVariables",
+                                      "path": ".env"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "title": "startRecording",
+                                  "type": "object",
+                                  "description": "Start recording the current browser viewport. Must be followed by a `stopRecording` action. Only runs when the context `app` is `chrome` and `headless` is `false`. Supported extensions: [ '.mp4', '.webm', '.gif' ]",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "ID of the step."
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Description of the step."
+                                    },
+                                    "action": {
+                                      "type": "string",
+                                      "const": "startRecording",
+                                      "description": "The action to perform."
+                                    },
+                                    "path": {
+                                      "type": "string",
+                                      "description": "File path of the recording. Supports the `.mp4`, `.webm`, and `.gif` extensions. If not specified, the file path is your media directory, the file name is the ID of the step, and the extension is `.mp4`.",
+                                      "pattern": "([A-Za-z0-9_-]*\\.(mp4|webm|gif)$|\\$[A-Za-z0-9_]+)"
+                                    },
+                                    "directory": {
+                                      "type": "string",
+                                      "description": "Directory of the file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                                    },
+                                    "overwrite": {
+                                      "type": "boolean",
+                                      "description": "If `true`, overwrites the existing file at `path` if it exists.",
+                                      "default": false
+                                    }
+                                  },
+                                  "dynamicDefaults": {
+                                    "id": "uuid"
+                                  },
+                                  "required": [
+                                    "action"
+                                  ],
+                                  "additionalProperties": false,
+                                  "examples": [
+                                    {
+                                      "action": "startRecording"
+                                    },
+                                    {
+                                      "action": "startRecording",
+                                      "path": "results.mp4"
+                                    },
+                                    {
+                                      "action": "startRecording",
+                                      "path": "results.mp4",
+                                      "directory": "static/media",
+                                      "overwrite": true
+                                    }
+                                  ]
+                                },
+                                {
+                                  "title": "stopRecording",
+                                  "type": "object",
+                                  "description": "Stop the current recording.",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "ID of the step."
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Description of the step."
+                                    },
+                                    "action": {
+                                      "type": "string",
+                                      "const": "stopRecording",
+                                      "description": "The action to perform."
+                                    }
+                                  },
+                                  "dynamicDefaults": {
+                                    "id": "uuid"
+                                  },
+                                  "required": [
+                                    "action"
+                                  ],
+                                  "additionalProperties": false,
+                                  "examples": [
+                                    {
+                                      "action": "stopRecording"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "title": "typeKeys",
+                                  "type": "object",
+                                  "description": "Type keys. To type special keys, begin and end the string with `$` and use the [special key's enum](). For example, to type the Escape key, enter `$ESCAPE$`.",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "ID of the step."
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Description of the step."
+                                    },
+                                    "action": {
+                                      "type": "string",
+                                      "const": "typeKeys",
+                                      "description": "The action to perform."
+                                    },
+                                    "keys": {
+                                      "description": "String of keys to enter.",
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "string"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "delay": {
+                                      "type": "number",
+                                      "description": "Delay in milliseconds between each key press. Only valid during a recording.",
+                                      "default": 100
+                                    }
+                                  },
+                                  "dynamicDefaults": {
+                                    "id": "uuid"
+                                  },
+                                  "required": [
+                                    "action",
+                                    "keys"
+                                  ],
+                                  "additionalProperties": false,
+                                  "examples": [
+                                    {
+                                      "action": "typeKeys",
+                                      "keys": "kittens"
+                                    },
+                                    {
+                                      "action": "typeKeys",
+                                      "keys": [
+                                        "$ENTER$"
+                                      ]
+                                    },
+                                    {
+                                      "action": "typeKeys",
+                                      "keys": [
+                                        "kittens",
+                                        "$ENTER$"
+                                      ],
+                                      "delay": 500
+                                    }
+                                  ]
+                                },
+                                {
+                                  "title": "wait",
+                                  "type": "object",
+                                  "description": "Pause before performing the next action.",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "ID of the step."
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Description of the step."
+                                    },
+                                    "action": {
+                                      "type": "string",
+                                      "const": "wait",
+                                      "description": "The action to perform."
+                                    },
+                                    "duration": {
+                                      "type": "number",
+                                      "description": "Milliseconds to wait.",
+                                      "default": 5000
+                                    }
+                                  },
+                                  "dynamicDefaults": {
+                                    "id": "uuid"
+                                  },
+                                  "required": [
+                                    "action"
+                                  ],
+                                  "additionalProperties": false,
+                                  "examples": [
+                                    {
+                                      "action": "wait"
+                                    },
+                                    {
+                                      "action": "wait",
+                                      "duration": 5000
+                                    }
                                   ]
                                 }
                               ]
@@ -633,9 +1541,6 @@
                 "name": "emphasis",
                 "regex": [
                   "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
-                ],
-                "actions": [
-                  "find"
                 ]
               },
               {
@@ -653,9 +1558,16 @@
                   "(?<!!)\\[.+?\\]\\(.+?\\)"
                 ],
                 "actions": [
-                  "checkLink",
-                  "goTo",
-                  "httpRequest"
+                  "checkLink"
+                ]
+              },
+              {
+                "name": "navigationLink",
+                "regex": [
+                  "(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"
+                ],
+                "actions": [
+                  "goTo"
                 ]
               },
               {
@@ -675,22 +1587,12 @@
                 "name": "codeInline",
                 "regex": [
                   "(?<!`)`(?!`).+?(?<!`)`(?!`)"
-                ],
-                "actions": [
-                  "runShell",
-                  "setVariables",
-                  "httpRequest"
                 ]
               },
               {
                 "name": "codeBlock",
                 "regex": [
                   "(?=(```))(\\w|\\W)*(?<=```)"
-                ],
-                "actions": [
-                  "runShell",
-                  "setVariables",
-                  "httpRequest"
                 ]
               },
               {
@@ -740,17 +1642,6 @@
                   "[rR]etry",
                   "[rR]estart",
                   "[rR]esume"
-                ],
-                "actions": [
-                  "checkLink",
-                  "find",
-                  "goTo",
-                  "httpRequest",
-                  "runShell",
-                  "saveScreenshot",
-                  "setVariables",
-                  "typeKeys",
-                  "wait"
                 ]
               }
             ]
@@ -943,6 +1834,7 @@
             "name": "Markdown",
             "extensions": [
               ".md",
+              ".markdown",
               ".mdx"
             ],
             "testStartStatementOpen": "[comment]: # (test start",
@@ -958,22 +1850,13 @@
                   "\\*\\*.+?\\*\\*"
                 ],
                 "actions": [
-                  {
-                    "name": "find",
-                    "params": {
-                      "moveTo": true,
-                      "click": true
-                    }
-                  }
+                  "find"
                 ]
               },
               {
                 "name": "emphasis",
                 "regex": [
                   "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
-                ],
-                "actions": [
-                  "find"
                 ]
               },
               {
@@ -991,9 +1874,16 @@
                   "(?<!!)\\[.+?\\]\\(.+?\\)"
                 ],
                 "actions": [
-                  "checkLink",
-                  "goTo",
-                  "httpRequest"
+                  "checkLink"
+                ]
+              },
+              {
+                "name": "navigationLink",
+                "regex": [
+                  "(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"
+                ],
+                "actions": [
+                  "goTo"
                 ]
               },
               {
@@ -1013,22 +1903,12 @@
                 "name": "codeInline",
                 "regex": [
                   "(?<!`)`(?!`).+?(?<!`)`(?!`)"
-                ],
-                "actions": [
-                  "runShell",
-                  "setVariables",
-                  "httpRequest"
                 ]
               },
               {
                 "name": "codeBlock",
                 "regex": [
                   "(?=(```))(\\w|\\W)*(?<=```)"
-                ],
-                "actions": [
-                  "runShell",
-                  "setVariables",
-                  "httpRequest"
                 ]
               },
               {
@@ -1078,17 +1958,6 @@
                   "[rR]etry",
                   "[rR]estart",
                   "[rR]esume"
-                ],
-                "actions": [
-                  "checkLink",
-                  "find",
-                  "goTo",
-                  "httpRequest",
-                  "runShell",
-                  "saveScreenshot",
-                  "setVariables",
-                  "typeKeys",
-                  "wait"
                 ]
               }
             ]
@@ -1153,6 +2022,7 @@
             "name": "Markdown",
             "extensions": [
               ".md",
+              ".markdown",
               ".mdx"
             ],
             "testStartStatementOpen": "[comment]: # (test start",
@@ -1175,9 +2045,6 @@
                 "name": "emphasis",
                 "regex": [
                   "(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"
-                ],
-                "actions": [
-                  "find"
                 ]
               },
               {
@@ -1195,9 +2062,16 @@
                   "(?<!!)\\[.+?\\]\\(.+?\\)"
                 ],
                 "actions": [
-                  "checkLink",
-                  "goTo",
-                  "httpRequest"
+                  "checkLink"
+                ]
+              },
+              {
+                "name": "navigationLink",
+                "regex": [
+                  "(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"
+                ],
+                "actions": [
+                  "goTo"
                 ]
               },
               {
@@ -1217,22 +2091,12 @@
                 "name": "codeInline",
                 "regex": [
                   "(?<!`)`(?!`).+?(?<!`)`(?!`)"
-                ],
-                "actions": [
-                  "runShell",
-                  "setVariables",
-                  "httpRequest"
                 ]
               },
               {
                 "name": "codeBlock",
                 "regex": [
                   "(?=(```))(\\w|\\W)*(?<=```)"
-                ],
-                "actions": [
-                  "runShell",
-                  "setVariables",
-                  "httpRequest"
                 ]
               },
               {
@@ -1282,20 +2146,39 @@
                   "[rR]etry",
                   "[rR]estart",
                   "[rR]esume"
-                ],
-                "actions": [
-                  "checkLink",
-                  "find",
-                  "goTo",
-                  "httpRequest",
-                  "runShell",
-                  "saveScreenshot",
-                  "setVariables",
-                  "typeKeys",
-                  "wait"
                 ]
               }
             ]
+          },
+          {
+            "name": "AsciiDoc",
+            "extensions": [
+              ".adoc",
+              ".asciidoc, .asc"
+            ],
+            "testStartStatementOpen": "// (test start",
+            "testStartStatementClose": ")",
+            "testIgnoreStatement": "// (test ignore)",
+            "testEndStatement": "// (test end)",
+            "stepStatementOpen": "// (step",
+            "stepStatementClose": ")",
+            "markup": []
+          },
+          {
+            "name": "HTML/XML",
+            "extensions": [
+              ".html",
+              ".htm",
+              ".xml",
+              ".xhtml"
+            ],
+            "testStartStatementOpen": "<!-- test start",
+            "testStartStatementClose": "-->",
+            "testIgnoreStatement": "<!-- test ignore -->",
+            "testEndStatement": "<!-- test end -->",
+            "stepStatementOpen": "<!-- step",
+            "stepStatementClose": "-->",
+            "markup": []
           }
         ],
         "integrations": {},

--- a/src/schemas/src_schemas/config_v2.schema.json
+++ b/src/schemas/src_schemas/config_v2.schema.json
@@ -260,6 +260,8 @@
                                   "runShell",
                                   "saveScreenshot",
                                   "setVariables",
+                                  "startRecording",
+                                  "stopRecording",
                                   "typeKeys",
                                   "wait"
                                 ]
@@ -267,6 +269,7 @@
                               {
                                 "type": "object",
                                 "additionalProperties": false,
+                                "deprecated": true,
                                 "properties": {
                                   "name": {
                                     "description": "Name of the action.",
@@ -279,6 +282,8 @@
                                       "runShell",
                                       "saveScreenshot",
                                       "setVariables",
+                                      "startRecording",
+                                      "stopRecording",
                                       "typeKeys",
                                       "wait"
                                     ]
@@ -290,6 +295,39 @@
                                   }
                                 },
                                 "required": ["name"]
+                              },
+                              {
+                                "$ref": "checkLink_v2.schema.json#"
+                              },
+                              {
+                                "$ref": "find_v2.schema.json#"
+                              },
+                              {
+                                "$ref": "goTo_v2.schema.json#"
+                              },
+                              {
+                                "$ref": "httpRequest_v2.schema.json#"
+                              },
+                              {
+                                "$ref": "runShell_v2.schema.json#"
+                              },
+                              {
+                                "$ref": "saveScreenshot_v2.schema.json#"
+                              },
+                              {
+                                "$ref": "setVariables_v2.schema.json#"
+                              },
+                              {
+                                "$ref": "startRecording_v2.schema.json#"
+                              },
+                              {
+                                "$ref": "stopRecording_v2.schema.json#"
+                              },
+                              {
+                                "$ref": "typeKeys_v2.schema.json#"
+                              },
+                              {
+                                "$ref": "wait_v2.schema.json#"
                               }
                             ]
                           }
@@ -332,8 +370,7 @@
             },
             {
               "name": "emphasis",
-              "regex": ["(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"],
-              "actions": ["find"]
+              "regex": ["(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"]
             },
             {
               "name": "image",
@@ -343,7 +380,12 @@
             {
               "name": "hyperlink",
               "regex": ["(?<!!)\\[.+?\\]\\(.+?\\)"],
-              "actions": ["checkLink", "goTo", "httpRequest"]
+              "actions": ["checkLink"]
+            },
+            {
+              "name": "navigationLink",
+              "regex": ["(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"],
+              "actions": ["goTo"]
             },
             {
               "name": "orderedList",
@@ -355,13 +397,11 @@
             },
             {
               "name": "codeInline",
-              "regex": ["(?<!`)`(?!`).+?(?<!`)`(?!`)"],
-              "actions": ["runShell", "setVariables", "httpRequest"]
+              "regex": ["(?<!`)`(?!`).+?(?<!`)`(?!`)"]
             },
             {
               "name": "codeBlock",
-              "regex": ["(?=(```))(\\w|\\W)*(?<=```)"],
-              "actions": ["runShell", "setVariables", "httpRequest"]
+              "regex": ["(?=(```))(\\w|\\W)*(?<=```)"]
             },
             {
               "name": "interaction",
@@ -410,17 +450,6 @@
                 "[rR]etry",
                 "[rR]estart",
                 "[rR]esume"
-              ],
-              "actions": [
-                "checkLink",
-                "find",
-                "goTo",
-                "httpRequest",
-                "runShell",
-                "saveScreenshot",
-                "setVariables",
-                "typeKeys",
-                "wait"
               ]
             }
           ]
@@ -587,7 +616,7 @@
       "fileTypes": [
         {
           "name": "Markdown",
-          "extensions": [".md", ".mdx"],
+          "extensions": [".md", ".markdown", ".mdx"],
           "testStartStatementOpen": "[comment]: # (test start",
           "testStartStatementClose": ")",
           "testIgnoreStatement": "[comment]: # (test ignore)",
@@ -598,20 +627,11 @@
             {
               "name": "onscreenText",
               "regex": ["\\*\\*.+?\\*\\*"],
-              "actions": [
-                {
-                  "name": "find",
-                  "params": {
-                    "moveTo": true,
-                    "click": true
-                  }
-                }
-              ]
+              "actions": ["find"]
             },
             {
               "name": "emphasis",
-              "regex": ["(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"],
-              "actions": ["find"]
+              "regex": ["(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"]
             },
             {
               "name": "image",
@@ -621,7 +641,12 @@
             {
               "name": "hyperlink",
               "regex": ["(?<!!)\\[.+?\\]\\(.+?\\)"],
-              "actions": ["checkLink", "goTo", "httpRequest"]
+              "actions": ["checkLink"]
+            },
+            {
+              "name": "navigationLink",
+              "regex": ["(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"],
+              "actions": ["goTo"]
             },
             {
               "name": "orderedList",
@@ -633,13 +658,11 @@
             },
             {
               "name": "codeInline",
-              "regex": ["(?<!`)`(?!`).+?(?<!`)`(?!`)"],
-              "actions": ["runShell", "setVariables", "httpRequest"]
+              "regex": ["(?<!`)`(?!`).+?(?<!`)`(?!`)"]
             },
             {
               "name": "codeBlock",
-              "regex": ["(?=(```))(\\w|\\W)*(?<=```)"],
-              "actions": ["runShell", "setVariables", "httpRequest"]
+              "regex": ["(?=(```))(\\w|\\W)*(?<=```)"]
             },
             {
               "name": "interaction",
@@ -688,17 +711,6 @@
                 "[rR]etry",
                 "[rR]estart",
                 "[rR]esume"
-              ],
-              "actions": [
-                "checkLink",
-                "find",
-                "goTo",
-                "httpRequest",
-                "runShell",
-                "saveScreenshot",
-                "setVariables",
-                "typeKeys",
-                "wait"
               ]
             }
           ]
@@ -747,7 +759,7 @@
       "fileTypes": [
         {
           "name": "Markdown",
-          "extensions": [".md", ".mdx"],
+          "extensions": [".md", ".markdown", ".mdx"],
           "testStartStatementOpen": "[comment]: # (test start",
           "testStartStatementClose": ")",
           "testIgnoreStatement": "[comment]: # (test ignore)",
@@ -762,8 +774,7 @@
             },
             {
               "name": "emphasis",
-              "regex": ["(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"],
-              "actions": ["find"]
+              "regex": ["(?<!\\*)\\*(?!\\*).+?(?<!\\*)\\*(?!\\*)"]
             },
             {
               "name": "image",
@@ -773,7 +784,12 @@
             {
               "name": "hyperlink",
               "regex": ["(?<!!)\\[.+?\\]\\(.+?\\)"],
-              "actions": ["checkLink", "goTo", "httpRequest"]
+              "actions": ["checkLink"]
+            },
+            {
+              "name": "navigationLink",
+              "regex": ["(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"],
+              "actions": ["goTo"]
             },
             {
               "name": "orderedList",
@@ -785,13 +801,11 @@
             },
             {
               "name": "codeInline",
-              "regex": ["(?<!`)`(?!`).+?(?<!`)`(?!`)"],
-              "actions": ["runShell", "setVariables", "httpRequest"]
+              "regex": ["(?<!`)`(?!`).+?(?<!`)`(?!`)"]
             },
             {
               "name": "codeBlock",
-              "regex": ["(?=(```))(\\w|\\W)*(?<=```)"],
-              "actions": ["runShell", "setVariables", "httpRequest"]
+              "regex": ["(?=(```))(\\w|\\W)*(?<=```)"]
             },
             {
               "name": "interaction",
@@ -840,20 +854,31 @@
                 "[rR]etry",
                 "[rR]estart",
                 "[rR]esume"
-              ],
-              "actions": [
-                "checkLink",
-                "find",
-                "goTo",
-                "httpRequest",
-                "runShell",
-                "saveScreenshot",
-                "setVariables",
-                "typeKeys",
-                "wait"
               ]
             }
           ]
+        },
+        {
+          "name": "AsciiDoc",
+          "extensions": [".adoc", ".asciidoc, .asc"],
+          "testStartStatementOpen": "// (test start",
+          "testStartStatementClose": ")",
+          "testIgnoreStatement": "// (test ignore)",
+          "testEndStatement": "// (test end)",
+          "stepStatementOpen": "// (step",
+          "stepStatementClose": ")",
+          "markup": []
+        },
+        {
+          "name": "HTML/XML",
+          "extensions": [".html", ".htm", ".xml", ".xhtml"],
+          "testStartStatementOpen": "<!-- test start",
+          "testStartStatementClose": "-->",
+          "testIgnoreStatement": "<!-- test ignore -->",
+          "testEndStatement": "<!-- test end -->",
+          "stepStatementOpen": "<!-- step",
+          "stepStatementClose": "-->",
+          "markup": []
         }
       ],
       "integrations": {},


### PR DESCRIPTION
Added support for using capture groups in markup regex and specifying markup actions with full step definitions instead of piecemeal param overlays. Also updated default Markdown regexes to use capture groups.