### PR TITLE
v1.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.1-dev.0",
+  "version": "1.16.1-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.16.1-dev.0",
+      "version": "1.16.1-dev.1",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.1-dev.1",
+  "version": "1.16.1-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.16.1-dev.1",
+      "version": "1.16.1-dev.2",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.0",
+  "version": "1.16.1-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.16.0",
+      "version": "1.16.1-dev.0",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.6.1",
+        "@apidevtools/json-schema-ref-parser": "^11.6.3",
         "ajv": "8.12.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^3.0.1",
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.6.1",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.1.tgz",
-      "integrity": "sha512-DxjgKBCoyReu4p5HMvpmgSOfRhhBcuf5V5soDDRgOTZMwsA4KSFzol1abFZgiCTE11L2kKGca5Md9GwDdXVBwQ==",
+      "version": "11.6.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.3.tgz",
+      "integrity": "sha512-lzKdPBz+Eo7xo7GUB2buWl4sqvUhHnMXrde1aRnj2kgbol6S8ZaHviDhKIif5M/q9E0A5ZVp3P9ZBPZnENcUHQ==",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.1-dev.2",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.16.1-dev.2",
+      "version": "1.16.1",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.1-dev.1",
+  "version": "1.16.1-dev.2",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.1-dev.2",
+  "version": "1.16.1",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.1-dev.0",
+  "version": "1.16.1-dev.1",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.16.0",
+  "version": "1.16.1-dev.0",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "jest": "^29.7.0"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^11.6.1",
+    "@apidevtools/json-schema-ref-parser": "^11.6.3",
     "ajv": "8.12.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -782,7 +782,7 @@
                                   "action": {
                                     "type": "string",
                                     "const": "httpRequest",
-                                    "description": "Aciton to perform."
+                                    "description": "Action to perform."
                                   },
                                   "url": {
                                     "type": "string",

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -844,7 +844,7 @@
                                     "properties": {}
                                   },
                                   "responseParams": {
-                                    "description": "Deprecated.",
+                                    "description": "",
                                     "deprecated": true,
                                     "type": "object",
                                     "additionalProperties": true,

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -844,7 +844,8 @@
                                     "properties": {}
                                   },
                                   "responseParams": {
-                                    "description": "URL parameters expected in the response, in key/value format. If one or more `responseParams` entries aren't present in the response, the step fails.",
+                                    "description": "Deprecated.",
+                                    "deprecated": true,
                                     "type": "object",
                                     "additionalProperties": true,
                                     "default": {},

--- a/src/schemas/output_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/output_schemas/httpRequest_v2.schema.json
@@ -76,7 +76,8 @@
       "properties": {}
     },
     "responseParams": {
-      "description": "URL parameters expected in the response, in key/value format. If one or more `responseParams` entries aren't present in the response, the step fails.",
+      "description": "Deprecated.",
+      "deprecated": true,
       "type": "object",
       "additionalProperties": true,
       "default": {},

--- a/src/schemas/output_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/output_schemas/httpRequest_v2.schema.json
@@ -14,7 +14,7 @@
     "action": {
       "type": "string",
       "const": "httpRequest",
-      "description": "Aciton to perform."
+      "description": "Action to perform."
     },
     "url": {
       "type": "string",

--- a/src/schemas/output_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/output_schemas/httpRequest_v2.schema.json
@@ -76,7 +76,7 @@
       "properties": {}
     },
     "responseParams": {
-      "description": "Deprecated.",
+      "description": "",
       "deprecated": true,
       "type": "object",
       "additionalProperties": true,

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -457,7 +457,7 @@
                         "action": {
                           "type": "string",
                           "const": "httpRequest",
-                          "description": "Aciton to perform."
+                          "description": "Action to perform."
                         },
                         "url": {
                           "type": "string",

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -519,7 +519,7 @@
                           "properties": {}
                         },
                         "responseParams": {
-                          "description": "Deprecated.",
+                          "description": "",
                           "deprecated": true,
                           "type": "object",
                           "additionalProperties": true,

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -519,7 +519,8 @@
                           "properties": {}
                         },
                         "responseParams": {
-                          "description": "URL parameters expected in the response, in key/value format. If one or more `responseParams` entries aren't present in the response, the step fails.",
+                          "description": "Deprecated.",
+                          "deprecated": true,
                           "type": "object",
                           "additionalProperties": true,
                           "default": {},

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -313,7 +313,7 @@
               "action": {
                 "type": "string",
                 "const": "httpRequest",
-                "description": "Aciton to perform."
+                "description": "Action to perform."
               },
               "url": {
                 "type": "string",

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -375,7 +375,7 @@
                 "properties": {}
               },
               "responseParams": {
-                "description": "Deprecated.",
+                "description": "",
                 "deprecated": true,
                 "type": "object",
                 "additionalProperties": true,

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -375,7 +375,8 @@
                 "properties": {}
               },
               "responseParams": {
-                "description": "URL parameters expected in the response, in key/value format. If one or more `responseParams` entries aren't present in the response, the step fails.",
+                "description": "Deprecated.",
+                "deprecated": true,
                 "type": "object",
                 "additionalProperties": true,
                 "default": {},

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -863,7 +863,7 @@
                                     "action": {
                                       "type": "string",
                                       "const": "httpRequest",
-                                      "description": "Aciton to perform."
+                                      "description": "Action to perform."
                                     },
                                     "url": {
                                       "type": "string",
@@ -2503,7 +2503,7 @@
       "action": {
         "type": "string",
         "const": "httpRequest",
-        "description": "Aciton to perform."
+        "description": "Action to perform."
       },
       "url": {
         "type": "string",
@@ -3573,7 +3573,7 @@
                           "action": {
                             "type": "string",
                             "const": "httpRequest",
-                            "description": "Aciton to perform."
+                            "description": "Action to perform."
                           },
                           "url": {
                             "type": "string",
@@ -4866,7 +4866,7 @@
                 "action": {
                   "type": "string",
                   "const": "httpRequest",
-                  "description": "Aciton to perform."
+                  "description": "Action to perform."
                 },
                 "url": {
                   "type": "string",

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -925,7 +925,8 @@
                                       "properties": {}
                                     },
                                     "responseParams": {
-                                      "description": "URL parameters expected in the response, in key/value format. If one or more `responseParams` entries aren't present in the response, the step fails.",
+                                      "description": "Deprecated.",
+                                      "deprecated": true,
                                       "type": "object",
                                       "additionalProperties": true,
                                       "default": {},
@@ -2564,7 +2565,8 @@
         "properties": {}
       },
       "responseParams": {
-        "description": "URL parameters expected in the response, in key/value format. If one or more `responseParams` entries aren't present in the response, the step fails.",
+        "description": "Deprecated.",
+        "deprecated": true,
         "type": "object",
         "additionalProperties": true,
         "default": {},
@@ -3633,7 +3635,8 @@
                             "properties": {}
                           },
                           "responseParams": {
-                            "description": "URL parameters expected in the response, in key/value format. If one or more `responseParams` entries aren't present in the response, the step fails.",
+                            "description": "Deprecated.",
+                            "deprecated": true,
                             "type": "object",
                             "additionalProperties": true,
                             "default": {},
@@ -4925,7 +4928,8 @@
                   "properties": {}
                 },
                 "responseParams": {
-                  "description": "URL parameters expected in the response, in key/value format. If one or more `responseParams` entries aren't present in the response, the step fails.",
+                  "description": "Deprecated.",
+                  "deprecated": true,
                   "type": "object",
                   "additionalProperties": true,
                   "default": {},

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -925,7 +925,7 @@
                                       "properties": {}
                                     },
                                     "responseParams": {
-                                      "description": "Deprecated.",
+                                      "description": "",
                                       "deprecated": true,
                                       "type": "object",
                                       "additionalProperties": true,
@@ -2565,7 +2565,7 @@
         "properties": {}
       },
       "responseParams": {
-        "description": "Deprecated.",
+        "description": "",
         "deprecated": true,
         "type": "object",
         "additionalProperties": true,
@@ -3635,7 +3635,7 @@
                             "properties": {}
                           },
                           "responseParams": {
-                            "description": "Deprecated.",
+                            "description": "",
                             "deprecated": true,
                             "type": "object",
                             "additionalProperties": true,
@@ -4928,7 +4928,7 @@
                   "properties": {}
                 },
                 "responseParams": {
-                  "description": "Deprecated.",
+                  "description": "",
                   "deprecated": true,
                   "type": "object",
                   "additionalProperties": true,

--- a/src/schemas/src_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/src_schemas/httpRequest_v2.schema.json
@@ -63,7 +63,8 @@
       "properties": {}
     },
     "responseParams": {
-      "description": "URL parameters expected in the response, in key/value format. If one or more `responseParams` entries aren't present in the response, the step fails.",
+      "description": "Deprecated.",
+      "deprecated": true,
       "type": "object",
       "additionalProperties": true,
       "default": {},

--- a/src/schemas/src_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/src_schemas/httpRequest_v2.schema.json
@@ -14,7 +14,7 @@
     "action": {
       "type": "string",
       "const": "httpRequest",
-      "description": "Aciton to perform."
+      "description": "Action to perform."
     },
     "url": {
       "type": "string",

--- a/src/schemas/src_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/src_schemas/httpRequest_v2.schema.json
@@ -63,7 +63,7 @@
       "properties": {}
     },
     "responseParams": {
-      "description": "Deprecated.",
+      "description": "",
       "deprecated": true,
       "type": "object",
       "additionalProperties": true,


### PR DESCRIPTION
Marked `httpRequest`'s `responseParams` attribute as deprecated.