### PR TITLE
Save and diff results of runShell and httpRequest actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.18.0-dev.2",
+  "version": "1.18.0-dev.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.18.0-dev.2",
+      "version": "1.18.0-dev.3",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.18.0-dev.2",
+  "version": "1.18.0-dev.3",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -883,7 +883,7 @@
                                     "minimum": 0,
                                     "maximum": 100
                                   },
-                                  "overwriteOutput": {
+                                  "overwrite": {
                                     "type": "string",
                                     "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                                     "enum": [
@@ -1003,7 +1003,7 @@
                                     "savePath": "response.json",
                                     "saveDirectory": "media",
                                     "maxVariation": 5,
-                                    "overwriteOutput": "byVariation"
+                                    "overwrite": "byVariation"
                                   }
                                 ]
                               },
@@ -1074,7 +1074,7 @@
                                     "minimum": 0,
                                     "maximum": 100
                                   },
-                                  "overwriteOutput": {
+                                  "overwrite": {
                                     "type": "string",
                                     "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                                     "enum": [
@@ -1185,7 +1185,7 @@
                                     "savePath": "docker-output.txt",
                                     "saveDirectory": "output",
                                     "maxVariation": 10,
-                                    "overwriteOutput": "byVariation"
+                                    "overwrite": "byVariation"
                                   }
                                 ]
                               },

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -868,6 +868,31 @@
                                     "default": {},
                                     "properties": {}
                                   },
+                                  "savePath": {
+                                    "type": "string",
+                                    "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+                                  },
+                                  "saveDirectory": {
+                                    "type": "string",
+                                    "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                                  },
+                                  "maxVariation": {
+                                    "type": "integer",
+                                    "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                                    "default": 0,
+                                    "minimum": 0,
+                                    "maximum": 100
+                                  },
+                                  "overwriteOutput": {
+                                    "type": "string",
+                                    "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                                    "enum": [
+                                      "true",
+                                      "false",
+                                      "byVariation"
+                                    ],
+                                    "default": "false"
+                                  },
                                   "envsFromResponseData": {
                                     "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                                     "type": "array",
@@ -958,6 +983,27 @@
                                     "statusCodes": [
                                       200
                                     ]
+                                  },
+                                  {
+                                    "action": "httpRequest",
+                                    "url": "https://reqres.in/api/users",
+                                    "method": "post",
+                                    "requestData": {
+                                      "name": "morpheus",
+                                      "job": "leader"
+                                    },
+                                    "responseData": {
+                                      "name": "morpheus",
+                                      "job": "leader"
+                                    },
+                                    "statusCodes": [
+                                      200,
+                                      201
+                                    ],
+                                    "savePath": "response.json",
+                                    "saveDirectory": "media",
+                                    "maxVariation": 5,
+                                    "overwriteOutput": "byVariation"
                                   }
                                 ]
                               },
@@ -1012,6 +1058,31 @@
                                   "output": {
                                     "type": "string",
                                     "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                                  },
+                                  "savePath": {
+                                    "type": "string",
+                                    "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+                                  },
+                                  "saveDirectory": {
+                                    "type": "string",
+                                    "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                                  },
+                                  "maxVariation": {
+                                    "type": "integer",
+                                    "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                                    "default": 0,
+                                    "minimum": 0,
+                                    "maximum": 100
+                                  },
+                                  "overwriteOutput": {
+                                    "type": "string",
+                                    "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                                    "enum": [
+                                      "true",
+                                      "false",
+                                      "byVariation"
+                                    ],
+                                    "default": "false"
                                   },
                                   "timeout": {
                                     "type": "integer",
@@ -1103,6 +1174,18 @@
                                         "regex": ".*"
                                       }
                                     ]
+                                  },
+                                  {
+                                    "action": "runShell",
+                                    "command": "docker run hello-world",
+                                    "exitCodes": [
+                                      0
+                                    ],
+                                    "output": "Hello from Docker!",
+                                    "savePath": "docker-output.txt",
+                                    "saveDirectory": "output",
+                                    "maxVariation": 10,
+                                    "overwriteOutput": "byVariation"
                                   }
                                 ]
                               },
@@ -1126,16 +1209,17 @@
                                   },
                                   "path": {
                                     "type": "string",
-                                    "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                                    "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                                     "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
                                   },
                                   "directory": {
                                     "type": "string",
-                                    "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                                    "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
                                   },
                                   "maxVariation": {
                                     "type": "number",
                                     "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                                    "default": 5,
                                     "minimum": 0,
                                     "maximum": 100
                                   },
@@ -1147,7 +1231,7 @@
                                       "false",
                                       "byVariation"
                                     ],
-                                    "default": false
+                                    "default": "false"
                                   }
                                 },
                                 "dynamicDefaults": {

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -870,7 +870,7 @@
                                   },
                                   "savePath": {
                                     "type": "string",
-                                    "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+                                    "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
                                   },
                                   "saveDirectory": {
                                     "type": "string",
@@ -1061,7 +1061,7 @@
                                   },
                                   "savePath": {
                                     "type": "string",
-                                    "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+                                    "description": "File path to save the command's output, relative to `saveDirectory`."
                                   },
                                   "saveDirectory": {
                                     "type": "string",

--- a/src/schemas/output_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/output_schemas/httpRequest_v2.schema.json
@@ -116,7 +116,7 @@
       "minimum": 0,
       "maximum": 100
     },
-    "overwriteOutput": {
+    "overwrite": {
       "type": "string",
       "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
       "enum": [
@@ -236,7 +236,7 @@
       "savePath": "response.json",
       "saveDirectory": "media",
       "maxVariation": 5,
-      "overwriteOutput": "byVariation"
+      "overwrite": "byVariation"
     }
   ]
 }

--- a/src/schemas/output_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/output_schemas/httpRequest_v2.schema.json
@@ -103,7 +103,7 @@
     },
     "savePath": {
       "type": "string",
-      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+      "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
     },
     "saveDirectory": {
       "type": "string",

--- a/src/schemas/output_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/output_schemas/httpRequest_v2.schema.json
@@ -101,6 +101,31 @@
       "default": {},
       "properties": {}
     },
+    "savePath": {
+      "type": "string",
+      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+    },
+    "saveDirectory": {
+      "type": "string",
+      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+    },
+    "maxVariation": {
+      "type": "integer",
+      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 100
+    },
+    "overwriteOutput": {
+      "type": "string",
+      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+      "enum": [
+        "true",
+        "false",
+        "byVariation"
+      ],
+      "default": "false"
+    },
     "envsFromResponseData": {
       "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
       "type": "array",
@@ -191,6 +216,27 @@
       "statusCodes": [
         200
       ]
+    },
+    {
+      "action": "httpRequest",
+      "url": "https://reqres.in/api/users",
+      "method": "post",
+      "requestData": {
+        "name": "morpheus",
+        "job": "leader"
+      },
+      "responseData": {
+        "name": "morpheus",
+        "job": "leader"
+      },
+      "statusCodes": [
+        200,
+        201
+      ],
+      "savePath": "response.json",
+      "saveDirectory": "media",
+      "maxVariation": 5,
+      "overwriteOutput": "byVariation"
     }
   ]
 }

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -50,6 +50,31 @@
       "type": "string",
       "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
     },
+    "savePath": {
+      "type": "string",
+      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+    },
+    "saveDirectory": {
+      "type": "string",
+      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+    },
+    "maxVariation": {
+      "type": "integer",
+      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 100
+    },
+    "overwriteOutput": {
+      "type": "string",
+      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+      "enum": [
+        "true",
+        "false",
+        "byVariation"
+      ],
+      "default": "false"
+    },
     "timeout": {
       "type": "integer",
       "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
@@ -140,6 +165,18 @@
           "regex": ".*"
         }
       ]
+    },
+    {
+      "action": "runShell",
+      "command": "docker run hello-world",
+      "exitCodes": [
+        0
+      ],
+      "output": "Hello from Docker!",
+      "savePath": "docker-output.txt",
+      "saveDirectory": "output",
+      "maxVariation": 10,
+      "overwriteOutput": "byVariation"
     }
   ]
 }

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -65,7 +65,7 @@
       "minimum": 0,
       "maximum": 100
     },
-    "overwriteOutput": {
+    "overwrite": {
       "type": "string",
       "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
       "enum": [
@@ -176,7 +176,7 @@
       "savePath": "docker-output.txt",
       "saveDirectory": "output",
       "maxVariation": 10,
-      "overwriteOutput": "byVariation"
+      "overwrite": "byVariation"
     }
   ]
 }

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -52,7 +52,7 @@
     },
     "savePath": {
       "type": "string",
-      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+      "description": "File path to save the command's output, relative to `saveDirectory`."
     },
     "saveDirectory": {
       "type": "string",

--- a/src/schemas/output_schemas/saveScreenshot_v2.schema.json
+++ b/src/schemas/output_schemas/saveScreenshot_v2.schema.json
@@ -18,16 +18,17 @@
     },
     "path": {
       "type": "string",
-      "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+      "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
       "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
     },
     "directory": {
       "type": "string",
-      "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+      "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
     },
     "maxVariation": {
       "type": "number",
       "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+      "default": 5,
       "minimum": 0,
       "maximum": 100
     },
@@ -39,7 +40,7 @@
         "false",
         "byVariation"
       ],
-      "default": false
+      "default": "false"
     }
   },
   "dynamicDefaults": {

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -559,7 +559,7 @@
                           "minimum": 0,
                           "maximum": 100
                         },
-                        "overwriteOutput": {
+                        "overwrite": {
                           "type": "string",
                           "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                           "enum": [
@@ -679,7 +679,7 @@
                           "savePath": "response.json",
                           "saveDirectory": "media",
                           "maxVariation": 5,
-                          "overwriteOutput": "byVariation"
+                          "overwrite": "byVariation"
                         }
                       ]
                     },
@@ -750,7 +750,7 @@
                           "minimum": 0,
                           "maximum": 100
                         },
-                        "overwriteOutput": {
+                        "overwrite": {
                           "type": "string",
                           "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                           "enum": [
@@ -861,7 +861,7 @@
                           "savePath": "docker-output.txt",
                           "saveDirectory": "output",
                           "maxVariation": 10,
-                          "overwriteOutput": "byVariation"
+                          "overwrite": "byVariation"
                         }
                       ]
                     },

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -544,6 +544,31 @@
                           "default": {},
                           "properties": {}
                         },
+                        "savePath": {
+                          "type": "string",
+                          "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+                        },
+                        "saveDirectory": {
+                          "type": "string",
+                          "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                        },
+                        "maxVariation": {
+                          "type": "integer",
+                          "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                          "default": 0,
+                          "minimum": 0,
+                          "maximum": 100
+                        },
+                        "overwriteOutput": {
+                          "type": "string",
+                          "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                          "enum": [
+                            "true",
+                            "false",
+                            "byVariation"
+                          ],
+                          "default": "false"
+                        },
                         "envsFromResponseData": {
                           "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                           "type": "array",
@@ -634,6 +659,27 @@
                           "statusCodes": [
                             200
                           ]
+                        },
+                        {
+                          "action": "httpRequest",
+                          "url": "https://reqres.in/api/users",
+                          "method": "post",
+                          "requestData": {
+                            "name": "morpheus",
+                            "job": "leader"
+                          },
+                          "responseData": {
+                            "name": "morpheus",
+                            "job": "leader"
+                          },
+                          "statusCodes": [
+                            200,
+                            201
+                          ],
+                          "savePath": "response.json",
+                          "saveDirectory": "media",
+                          "maxVariation": 5,
+                          "overwriteOutput": "byVariation"
                         }
                       ]
                     },
@@ -688,6 +734,31 @@
                         "output": {
                           "type": "string",
                           "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                        },
+                        "savePath": {
+                          "type": "string",
+                          "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+                        },
+                        "saveDirectory": {
+                          "type": "string",
+                          "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                        },
+                        "maxVariation": {
+                          "type": "integer",
+                          "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                          "default": 0,
+                          "minimum": 0,
+                          "maximum": 100
+                        },
+                        "overwriteOutput": {
+                          "type": "string",
+                          "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                          "enum": [
+                            "true",
+                            "false",
+                            "byVariation"
+                          ],
+                          "default": "false"
                         },
                         "timeout": {
                           "type": "integer",
@@ -779,6 +850,18 @@
                               "regex": ".*"
                             }
                           ]
+                        },
+                        {
+                          "action": "runShell",
+                          "command": "docker run hello-world",
+                          "exitCodes": [
+                            0
+                          ],
+                          "output": "Hello from Docker!",
+                          "savePath": "docker-output.txt",
+                          "saveDirectory": "output",
+                          "maxVariation": 10,
+                          "overwriteOutput": "byVariation"
                         }
                       ]
                     },
@@ -802,16 +885,17 @@
                         },
                         "path": {
                           "type": "string",
-                          "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                          "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                           "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
                         },
                         "directory": {
                           "type": "string",
-                          "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                          "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
                         },
                         "maxVariation": {
                           "type": "number",
                           "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                          "default": 5,
                           "minimum": 0,
                           "maximum": 100
                         },
@@ -823,7 +907,7 @@
                             "false",
                             "byVariation"
                           ],
-                          "default": false
+                          "default": "false"
                         }
                       },
                       "dynamicDefaults": {

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -546,7 +546,7 @@
                         },
                         "savePath": {
                           "type": "string",
-                          "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+                          "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
                         },
                         "saveDirectory": {
                           "type": "string",
@@ -737,7 +737,7 @@
                         },
                         "savePath": {
                           "type": "string",
-                          "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+                          "description": "File path to save the command's output, relative to `saveDirectory`."
                         },
                         "saveDirectory": {
                           "type": "string",

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -400,6 +400,31 @@
                 "default": {},
                 "properties": {}
               },
+              "savePath": {
+                "type": "string",
+                "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+              },
+              "saveDirectory": {
+                "type": "string",
+                "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+              },
+              "maxVariation": {
+                "type": "integer",
+                "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                "default": 0,
+                "minimum": 0,
+                "maximum": 100
+              },
+              "overwriteOutput": {
+                "type": "string",
+                "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                "enum": [
+                  "true",
+                  "false",
+                  "byVariation"
+                ],
+                "default": "false"
+              },
               "envsFromResponseData": {
                 "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                 "type": "array",
@@ -490,6 +515,27 @@
                 "statusCodes": [
                   200
                 ]
+              },
+              {
+                "action": "httpRequest",
+                "url": "https://reqres.in/api/users",
+                "method": "post",
+                "requestData": {
+                  "name": "morpheus",
+                  "job": "leader"
+                },
+                "responseData": {
+                  "name": "morpheus",
+                  "job": "leader"
+                },
+                "statusCodes": [
+                  200,
+                  201
+                ],
+                "savePath": "response.json",
+                "saveDirectory": "media",
+                "maxVariation": 5,
+                "overwriteOutput": "byVariation"
               }
             ]
           },
@@ -544,6 +590,31 @@
               "output": {
                 "type": "string",
                 "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+              },
+              "savePath": {
+                "type": "string",
+                "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+              },
+              "saveDirectory": {
+                "type": "string",
+                "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+              },
+              "maxVariation": {
+                "type": "integer",
+                "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                "default": 0,
+                "minimum": 0,
+                "maximum": 100
+              },
+              "overwriteOutput": {
+                "type": "string",
+                "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                "enum": [
+                  "true",
+                  "false",
+                  "byVariation"
+                ],
+                "default": "false"
               },
               "timeout": {
                 "type": "integer",
@@ -635,6 +706,18 @@
                     "regex": ".*"
                   }
                 ]
+              },
+              {
+                "action": "runShell",
+                "command": "docker run hello-world",
+                "exitCodes": [
+                  0
+                ],
+                "output": "Hello from Docker!",
+                "savePath": "docker-output.txt",
+                "saveDirectory": "output",
+                "maxVariation": 10,
+                "overwriteOutput": "byVariation"
               }
             ]
           },
@@ -658,16 +741,17 @@
               },
               "path": {
                 "type": "string",
-                "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                 "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
               },
               "directory": {
                 "type": "string",
-                "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
               },
               "maxVariation": {
                 "type": "number",
                 "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                "default": 5,
                 "minimum": 0,
                 "maximum": 100
               },
@@ -679,7 +763,7 @@
                   "false",
                   "byVariation"
                 ],
-                "default": false
+                "default": "false"
               }
             },
             "dynamicDefaults": {

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -402,7 +402,7 @@
               },
               "savePath": {
                 "type": "string",
-                "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+                "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
               },
               "saveDirectory": {
                 "type": "string",
@@ -593,7 +593,7 @@
               },
               "savePath": {
                 "type": "string",
-                "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+                "description": "File path to save the command's output, relative to `saveDirectory`."
               },
               "saveDirectory": {
                 "type": "string",

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -415,7 +415,7 @@
                 "minimum": 0,
                 "maximum": 100
               },
-              "overwriteOutput": {
+              "overwrite": {
                 "type": "string",
                 "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                 "enum": [
@@ -535,7 +535,7 @@
                 "savePath": "response.json",
                 "saveDirectory": "media",
                 "maxVariation": 5,
-                "overwriteOutput": "byVariation"
+                "overwrite": "byVariation"
               }
             ]
           },
@@ -606,7 +606,7 @@
                 "minimum": 0,
                 "maximum": 100
               },
-              "overwriteOutput": {
+              "overwrite": {
                 "type": "string",
                 "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                 "enum": [
@@ -717,7 +717,7 @@
                 "savePath": "docker-output.txt",
                 "saveDirectory": "output",
                 "maxVariation": 10,
-                "overwriteOutput": "byVariation"
+                "overwrite": "byVariation"
               }
             ]
           },

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -949,6 +949,31 @@
                                       "default": {},
                                       "properties": {}
                                     },
+                                    "savePath": {
+                                      "type": "string",
+                                      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+                                    },
+                                    "saveDirectory": {
+                                      "type": "string",
+                                      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                                    },
+                                    "maxVariation": {
+                                      "type": "integer",
+                                      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                                      "default": 0,
+                                      "minimum": 0,
+                                      "maximum": 100
+                                    },
+                                    "overwriteOutput": {
+                                      "type": "string",
+                                      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                                      "enum": [
+                                        "true",
+                                        "false",
+                                        "byVariation"
+                                      ],
+                                      "default": "false"
+                                    },
                                     "envsFromResponseData": {
                                       "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                                       "type": "array",
@@ -1039,6 +1064,27 @@
                                       "statusCodes": [
                                         200
                                       ]
+                                    },
+                                    {
+                                      "action": "httpRequest",
+                                      "url": "https://reqres.in/api/users",
+                                      "method": "post",
+                                      "requestData": {
+                                        "name": "morpheus",
+                                        "job": "leader"
+                                      },
+                                      "responseData": {
+                                        "name": "morpheus",
+                                        "job": "leader"
+                                      },
+                                      "statusCodes": [
+                                        200,
+                                        201
+                                      ],
+                                      "savePath": "response.json",
+                                      "saveDirectory": "media",
+                                      "maxVariation": 5,
+                                      "overwriteOutput": "byVariation"
                                     }
                                   ]
                                 },
@@ -1093,6 +1139,31 @@
                                     "output": {
                                       "type": "string",
                                       "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                                    },
+                                    "savePath": {
+                                      "type": "string",
+                                      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+                                    },
+                                    "saveDirectory": {
+                                      "type": "string",
+                                      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                                    },
+                                    "maxVariation": {
+                                      "type": "integer",
+                                      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                                      "default": 0,
+                                      "minimum": 0,
+                                      "maximum": 100
+                                    },
+                                    "overwriteOutput": {
+                                      "type": "string",
+                                      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                                      "enum": [
+                                        "true",
+                                        "false",
+                                        "byVariation"
+                                      ],
+                                      "default": "false"
                                     },
                                     "timeout": {
                                       "type": "integer",
@@ -1184,6 +1255,18 @@
                                           "regex": ".*"
                                         }
                                       ]
+                                    },
+                                    {
+                                      "action": "runShell",
+                                      "command": "docker run hello-world",
+                                      "exitCodes": [
+                                        0
+                                      ],
+                                      "output": "Hello from Docker!",
+                                      "savePath": "docker-output.txt",
+                                      "saveDirectory": "output",
+                                      "maxVariation": 10,
+                                      "overwriteOutput": "byVariation"
                                     }
                                   ]
                                 },
@@ -1207,16 +1290,17 @@
                                     },
                                     "path": {
                                       "type": "string",
-                                      "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                                      "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                                       "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
                                     },
                                     "directory": {
                                       "type": "string",
-                                      "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                                      "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
                                     },
                                     "maxVariation": {
                                       "type": "number",
                                       "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                                      "default": 5,
                                       "minimum": 0,
                                       "maximum": 100
                                     },
@@ -1228,7 +1312,7 @@
                                         "false",
                                         "byVariation"
                                       ],
-                                      "default": false
+                                      "default": "false"
                                     }
                                   },
                                   "dynamicDefaults": {
@@ -2600,6 +2684,31 @@
         "default": {},
         "properties": {}
       },
+      "savePath": {
+        "type": "string",
+        "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+      },
+      "saveDirectory": {
+        "type": "string",
+        "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+      },
+      "maxVariation": {
+        "type": "integer",
+        "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+        "default": 0,
+        "minimum": 0,
+        "maximum": 100
+      },
+      "overwriteOutput": {
+        "type": "string",
+        "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+        "enum": [
+          "true",
+          "false",
+          "byVariation"
+        ],
+        "default": "false"
+      },
       "envsFromResponseData": {
         "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
         "type": "array",
@@ -2690,6 +2799,27 @@
         "statusCodes": [
           200
         ]
+      },
+      {
+        "action": "httpRequest",
+        "url": "https://reqres.in/api/users",
+        "method": "post",
+        "requestData": {
+          "name": "morpheus",
+          "job": "leader"
+        },
+        "responseData": {
+          "name": "morpheus",
+          "job": "leader"
+        },
+        "statusCodes": [
+          200,
+          201
+        ],
+        "savePath": "response.json",
+        "saveDirectory": "media",
+        "maxVariation": 5,
+        "overwriteOutput": "byVariation"
       }
     ]
   },
@@ -2843,6 +2973,31 @@
         "type": "string",
         "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
       },
+      "savePath": {
+        "type": "string",
+        "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+      },
+      "saveDirectory": {
+        "type": "string",
+        "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+      },
+      "maxVariation": {
+        "type": "integer",
+        "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+        "default": 0,
+        "minimum": 0,
+        "maximum": 100
+      },
+      "overwriteOutput": {
+        "type": "string",
+        "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+        "enum": [
+          "true",
+          "false",
+          "byVariation"
+        ],
+        "default": "false"
+      },
       "timeout": {
         "type": "integer",
         "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
@@ -2933,6 +3088,18 @@
             "regex": ".*"
           }
         ]
+      },
+      {
+        "action": "runShell",
+        "command": "docker run hello-world",
+        "exitCodes": [
+          0
+        ],
+        "output": "Hello from Docker!",
+        "savePath": "docker-output.txt",
+        "saveDirectory": "output",
+        "maxVariation": 10,
+        "overwriteOutput": "byVariation"
       }
     ]
   },
@@ -2956,16 +3123,17 @@
       },
       "path": {
         "type": "string",
-        "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+        "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
         "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
       },
       "directory": {
         "type": "string",
-        "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+        "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
       },
       "maxVariation": {
         "type": "number",
         "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+        "default": 5,
         "minimum": 0,
         "maximum": 100
       },
@@ -2977,7 +3145,7 @@
           "false",
           "byVariation"
         ],
-        "default": false
+        "default": "false"
       }
     },
     "dynamicDefaults": {
@@ -3681,6 +3849,31 @@
                             "default": {},
                             "properties": {}
                           },
+                          "savePath": {
+                            "type": "string",
+                            "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+                          },
+                          "saveDirectory": {
+                            "type": "string",
+                            "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                          },
+                          "maxVariation": {
+                            "type": "integer",
+                            "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                            "default": 0,
+                            "minimum": 0,
+                            "maximum": 100
+                          },
+                          "overwriteOutput": {
+                            "type": "string",
+                            "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                            "enum": [
+                              "true",
+                              "false",
+                              "byVariation"
+                            ],
+                            "default": "false"
+                          },
                           "envsFromResponseData": {
                             "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                             "type": "array",
@@ -3771,6 +3964,27 @@
                             "statusCodes": [
                               200
                             ]
+                          },
+                          {
+                            "action": "httpRequest",
+                            "url": "https://reqres.in/api/users",
+                            "method": "post",
+                            "requestData": {
+                              "name": "morpheus",
+                              "job": "leader"
+                            },
+                            "responseData": {
+                              "name": "morpheus",
+                              "job": "leader"
+                            },
+                            "statusCodes": [
+                              200,
+                              201
+                            ],
+                            "savePath": "response.json",
+                            "saveDirectory": "media",
+                            "maxVariation": 5,
+                            "overwriteOutput": "byVariation"
                           }
                         ]
                       },
@@ -3825,6 +4039,31 @@
                           "output": {
                             "type": "string",
                             "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                          },
+                          "savePath": {
+                            "type": "string",
+                            "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+                          },
+                          "saveDirectory": {
+                            "type": "string",
+                            "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                          },
+                          "maxVariation": {
+                            "type": "integer",
+                            "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                            "default": 0,
+                            "minimum": 0,
+                            "maximum": 100
+                          },
+                          "overwriteOutput": {
+                            "type": "string",
+                            "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                            "enum": [
+                              "true",
+                              "false",
+                              "byVariation"
+                            ],
+                            "default": "false"
                           },
                           "timeout": {
                             "type": "integer",
@@ -3916,6 +4155,18 @@
                                 "regex": ".*"
                               }
                             ]
+                          },
+                          {
+                            "action": "runShell",
+                            "command": "docker run hello-world",
+                            "exitCodes": [
+                              0
+                            ],
+                            "output": "Hello from Docker!",
+                            "savePath": "docker-output.txt",
+                            "saveDirectory": "output",
+                            "maxVariation": 10,
+                            "overwriteOutput": "byVariation"
                           }
                         ]
                       },
@@ -3939,16 +4190,17 @@
                           },
                           "path": {
                             "type": "string",
-                            "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                            "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                             "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
                           },
                           "directory": {
                             "type": "string",
-                            "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                            "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
                           },
                           "maxVariation": {
                             "type": "number",
                             "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                            "default": 5,
                             "minimum": 0,
                             "maximum": 100
                           },
@@ -3960,7 +4212,7 @@
                               "false",
                               "byVariation"
                             ],
-                            "default": false
+                            "default": "false"
                           }
                         },
                         "dynamicDefaults": {
@@ -4985,6 +5237,31 @@
                   "default": {},
                   "properties": {}
                 },
+                "savePath": {
+                  "type": "string",
+                  "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+                },
+                "saveDirectory": {
+                  "type": "string",
+                  "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                },
+                "maxVariation": {
+                  "type": "integer",
+                  "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "overwriteOutput": {
+                  "type": "string",
+                  "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                  "enum": [
+                    "true",
+                    "false",
+                    "byVariation"
+                  ],
+                  "default": "false"
+                },
                 "envsFromResponseData": {
                   "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                   "type": "array",
@@ -5075,6 +5352,27 @@
                   "statusCodes": [
                     200
                   ]
+                },
+                {
+                  "action": "httpRequest",
+                  "url": "https://reqres.in/api/users",
+                  "method": "post",
+                  "requestData": {
+                    "name": "morpheus",
+                    "job": "leader"
+                  },
+                  "responseData": {
+                    "name": "morpheus",
+                    "job": "leader"
+                  },
+                  "statusCodes": [
+                    200,
+                    201
+                  ],
+                  "savePath": "response.json",
+                  "saveDirectory": "media",
+                  "maxVariation": 5,
+                  "overwriteOutput": "byVariation"
                 }
               ]
             },
@@ -5129,6 +5427,31 @@
                 "output": {
                   "type": "string",
                   "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                },
+                "savePath": {
+                  "type": "string",
+                  "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+                },
+                "saveDirectory": {
+                  "type": "string",
+                  "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                },
+                "maxVariation": {
+                  "type": "integer",
+                  "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "overwriteOutput": {
+                  "type": "string",
+                  "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                  "enum": [
+                    "true",
+                    "false",
+                    "byVariation"
+                  ],
+                  "default": "false"
                 },
                 "timeout": {
                   "type": "integer",
@@ -5220,6 +5543,18 @@
                       "regex": ".*"
                     }
                   ]
+                },
+                {
+                  "action": "runShell",
+                  "command": "docker run hello-world",
+                  "exitCodes": [
+                    0
+                  ],
+                  "output": "Hello from Docker!",
+                  "savePath": "docker-output.txt",
+                  "saveDirectory": "output",
+                  "maxVariation": 10,
+                  "overwriteOutput": "byVariation"
                 }
               ]
             },
@@ -5243,16 +5578,17 @@
                 },
                 "path": {
                   "type": "string",
-                  "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                  "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                   "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
                 },
                 "directory": {
                   "type": "string",
-                  "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                  "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
                 },
                 "maxVariation": {
                   "type": "number",
                   "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                  "default": 5,
                   "minimum": 0,
                   "maximum": 100
                 },
@@ -5264,7 +5600,7 @@
                     "false",
                     "byVariation"
                   ],
-                  "default": false
+                  "default": "false"
                 }
               },
               "dynamicDefaults": {

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -964,7 +964,7 @@
                                       "minimum": 0,
                                       "maximum": 100
                                     },
-                                    "overwriteOutput": {
+                                    "overwrite": {
                                       "type": "string",
                                       "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                                       "enum": [
@@ -1084,7 +1084,7 @@
                                       "savePath": "response.json",
                                       "saveDirectory": "media",
                                       "maxVariation": 5,
-                                      "overwriteOutput": "byVariation"
+                                      "overwrite": "byVariation"
                                     }
                                   ]
                                 },
@@ -1155,7 +1155,7 @@
                                       "minimum": 0,
                                       "maximum": 100
                                     },
-                                    "overwriteOutput": {
+                                    "overwrite": {
                                       "type": "string",
                                       "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                                       "enum": [
@@ -1266,7 +1266,7 @@
                                       "savePath": "docker-output.txt",
                                       "saveDirectory": "output",
                                       "maxVariation": 10,
-                                      "overwriteOutput": "byVariation"
+                                      "overwrite": "byVariation"
                                     }
                                   ]
                                 },
@@ -2699,7 +2699,7 @@
         "minimum": 0,
         "maximum": 100
       },
-      "overwriteOutput": {
+      "overwrite": {
         "type": "string",
         "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
         "enum": [
@@ -2819,7 +2819,7 @@
         "savePath": "response.json",
         "saveDirectory": "media",
         "maxVariation": 5,
-        "overwriteOutput": "byVariation"
+        "overwrite": "byVariation"
       }
     ]
   },
@@ -2988,7 +2988,7 @@
         "minimum": 0,
         "maximum": 100
       },
-      "overwriteOutput": {
+      "overwrite": {
         "type": "string",
         "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
         "enum": [
@@ -3099,7 +3099,7 @@
         "savePath": "docker-output.txt",
         "saveDirectory": "output",
         "maxVariation": 10,
-        "overwriteOutput": "byVariation"
+        "overwrite": "byVariation"
       }
     ]
   },
@@ -3864,7 +3864,7 @@
                             "minimum": 0,
                             "maximum": 100
                           },
-                          "overwriteOutput": {
+                          "overwrite": {
                             "type": "string",
                             "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                             "enum": [
@@ -3984,7 +3984,7 @@
                             "savePath": "response.json",
                             "saveDirectory": "media",
                             "maxVariation": 5,
-                            "overwriteOutput": "byVariation"
+                            "overwrite": "byVariation"
                           }
                         ]
                       },
@@ -4055,7 +4055,7 @@
                             "minimum": 0,
                             "maximum": 100
                           },
-                          "overwriteOutput": {
+                          "overwrite": {
                             "type": "string",
                             "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                             "enum": [
@@ -4166,7 +4166,7 @@
                             "savePath": "docker-output.txt",
                             "saveDirectory": "output",
                             "maxVariation": 10,
-                            "overwriteOutput": "byVariation"
+                            "overwrite": "byVariation"
                           }
                         ]
                       },
@@ -5252,7 +5252,7 @@
                   "minimum": 0,
                   "maximum": 100
                 },
-                "overwriteOutput": {
+                "overwrite": {
                   "type": "string",
                   "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                   "enum": [
@@ -5372,7 +5372,7 @@
                   "savePath": "response.json",
                   "saveDirectory": "media",
                   "maxVariation": 5,
-                  "overwriteOutput": "byVariation"
+                  "overwrite": "byVariation"
                 }
               ]
             },
@@ -5443,7 +5443,7 @@
                   "minimum": 0,
                   "maximum": 100
                 },
-                "overwriteOutput": {
+                "overwrite": {
                   "type": "string",
                   "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
                   "enum": [
@@ -5554,7 +5554,7 @@
                   "savePath": "docker-output.txt",
                   "saveDirectory": "output",
                   "maxVariation": 10,
-                  "overwriteOutput": "byVariation"
+                  "overwrite": "byVariation"
                 }
               ]
             },

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -951,7 +951,7 @@
                                     },
                                     "savePath": {
                                       "type": "string",
-                                      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+                                      "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
                                     },
                                     "saveDirectory": {
                                       "type": "string",
@@ -1142,7 +1142,7 @@
                                     },
                                     "savePath": {
                                       "type": "string",
-                                      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+                                      "description": "File path to save the command's output, relative to `saveDirectory`."
                                     },
                                     "saveDirectory": {
                                       "type": "string",
@@ -2686,7 +2686,7 @@
       },
       "savePath": {
         "type": "string",
-        "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+        "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
       },
       "saveDirectory": {
         "type": "string",
@@ -2975,7 +2975,7 @@
       },
       "savePath": {
         "type": "string",
-        "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+        "description": "File path to save the command's output, relative to `saveDirectory`."
       },
       "saveDirectory": {
         "type": "string",
@@ -3851,7 +3851,7 @@
                           },
                           "savePath": {
                             "type": "string",
-                            "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+                            "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
                           },
                           "saveDirectory": {
                             "type": "string",
@@ -4042,7 +4042,7 @@
                           },
                           "savePath": {
                             "type": "string",
-                            "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+                            "description": "File path to save the command's output, relative to `saveDirectory`."
                           },
                           "saveDirectory": {
                             "type": "string",
@@ -5239,7 +5239,7 @@
                 },
                 "savePath": {
                   "type": "string",
-                  "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+                  "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
                 },
                 "saveDirectory": {
                   "type": "string",
@@ -5430,7 +5430,7 @@
                 },
                 "savePath": {
                   "type": "string",
-                  "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+                  "description": "File path to save the command's output, relative to `saveDirectory`."
                 },
                 "saveDirectory": {
                   "type": "string",

--- a/src/schemas/src_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/src_schemas/httpRequest_v2.schema.json
@@ -88,6 +88,31 @@
       "default": {},
       "properties": {}
     },
+    "savePath": {
+      "type": "string",
+      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+    },
+    "saveDirectory": {
+      "type": "string",
+      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+    },
+    "maxVariation": {
+      "type": "integer",
+      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 100
+    },
+    "overwriteOutput": {
+      "type": "string",
+      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+      "enum": [
+        "true",
+        "false",
+        "byVariation"
+      ],
+      "default": "false"
+    },
     "envsFromResponseData": {
       "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
       "type": "array",
@@ -167,6 +192,24 @@
         "field": "value"
       },
       "statusCodes": [200]
+    },
+    {
+      "action": "httpRequest",
+      "url": "https://reqres.in/api/users",
+      "method": "post",
+      "requestData": {
+        "name": "morpheus",
+        "job": "leader"
+      },
+      "responseData": {
+        "name": "morpheus",
+        "job": "leader"
+      },
+      "statusCodes": [200, 201],
+      "savePath": "response.json",
+      "saveDirectory": "media",
+      "maxVariation": 5,
+      "overwriteOutput": "byVariation"
     }
   ]
 }

--- a/src/schemas/src_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/src_schemas/httpRequest_v2.schema.json
@@ -103,7 +103,7 @@
       "minimum": 0,
       "maximum": 100
     },
-    "overwriteOutput": {
+    "overwrite": {
       "type": "string",
       "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
       "enum": [
@@ -209,7 +209,7 @@
       "savePath": "response.json",
       "saveDirectory": "media",
       "maxVariation": 5,
-      "overwriteOutput": "byVariation"
+      "overwrite": "byVariation"
     }
   ]
 }

--- a/src/schemas/src_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/src_schemas/httpRequest_v2.schema.json
@@ -90,7 +90,7 @@
     },
     "savePath": {
       "type": "string",
-      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.json` if the response is valid JSON or a `.txt` extension otherwise."
+      "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
     },
     "saveDirectory": {
       "type": "string",

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -63,7 +63,7 @@
       "minimum": 0,
       "maximum": 100
     },
-    "overwriteOutput": {
+    "overwrite": {
       "type": "string",
       "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
       "enum": [
@@ -154,7 +154,7 @@
       "savePath": "docker-output.txt",
       "saveDirectory": "output",
       "maxVariation": 10,
-      "overwriteOutput": "byVariation"
+      "overwrite": "byVariation"
     }
   ]
 }

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -48,6 +48,31 @@
       "type": "string",
       "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
     },
+    "savePath": {
+      "type": "string",
+      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+    },
+    "saveDirectory": {
+      "type": "string",
+      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+    },
+    "maxVariation": {
+      "type": "integer",
+      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 100
+    },
+    "overwriteOutput": {
+      "type": "string",
+      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+      "enum": [
+        "true",
+        "false",
+        "byVariation"
+      ],
+      "default": "false"
+    },
     "timeout": {
       "type": "integer",
       "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
@@ -120,6 +145,16 @@
           "regex": ".*"
         }
       ]
+    },
+    {
+      "action": "runShell",
+      "command": "docker run hello-world",
+      "exitCodes": [0],
+      "output": "Hello from Docker!",
+      "savePath": "docker-output.txt",
+      "saveDirectory": "output",
+      "maxVariation": 10,
+      "overwriteOutput": "byVariation"
     }
   ]
 }

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -50,7 +50,7 @@
     },
     "savePath": {
       "type": "string",
-      "description": "File path to save the command's output, relative to `saveDirectory`. If not specified, the file name is the ID of the step with a `.txt` extension."
+      "description": "File path to save the command's output, relative to `saveDirectory`."
     },
     "saveDirectory": {
       "type": "string",

--- a/src/schemas/src_schemas/saveScreenshot_v2.schema.json
+++ b/src/schemas/src_schemas/saveScreenshot_v2.schema.json
@@ -18,16 +18,17 @@
     },
     "path": {
       "type": "string",
-      "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+      "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
       "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
     },
     "directory": {
       "type": "string",
-      "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+      "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
     },
     "maxVariation": {
       "type": "number",
       "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+      "default": 5,
       "minimum": 0,
       "maximum": 100
     },
@@ -39,7 +40,7 @@
         "false",
         "byVariation"
       ],
-      "default": false
+      "default": "false"
     }
   },
   "dynamicDefaults": {


### PR DESCRIPTION
Mirroring the saveScreenshot behaviors, DD can now save, compare, and overwite outputs from runShell commands and response body data from httpRequests.