### PR TITLE
allowAdditionalFields boolean allows strict response matching

### DIFF
--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -905,6 +905,11 @@
                                     "default": {},
                                     "properties": {}
                                   },
+                                  "allowAdditionalFields": {
+                                    "type": "boolean",
+                                    "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                                    "default": true
+                                  },
                                   "savePath": {
                                     "type": "string",
                                     "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."

--- a/src/schemas/output_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/output_schemas/httpRequest_v2.schema.json
@@ -101,6 +101,11 @@
       "default": {},
       "properties": {}
     },
+    "allowAdditionalFields": {
+      "type": "boolean",
+      "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+      "default": true
+    },
     "savePath": {
       "type": "string",
       "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -544,6 +544,11 @@
                           "default": {},
                           "properties": {}
                         },
+                        "allowAdditionalFields": {
+                          "type": "boolean",
+                          "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                          "default": true
+                        },
                         "savePath": {
                           "type": "string",
                           "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -400,6 +400,11 @@
                 "default": {},
                 "properties": {}
               },
+              "allowAdditionalFields": {
+                "type": "boolean",
+                "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                "default": true
+              },
               "savePath": {
                 "type": "string",
                 "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -986,6 +986,11 @@
                                       "default": {},
                                       "properties": {}
                                     },
+                                    "allowAdditionalFields": {
+                                      "type": "boolean",
+                                      "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                                      "default": true
+                                    },
                                     "savePath": {
                                       "type": "string",
                                       "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
@@ -2758,6 +2763,11 @@
         "default": {},
         "properties": {}
       },
+      "allowAdditionalFields": {
+        "type": "boolean",
+        "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+        "default": true
+      },
       "savePath": {
         "type": "string",
         "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
@@ -3922,6 +3932,11 @@
                             "additionalProperties": true,
                             "default": {},
                             "properties": {}
+                          },
+                          "allowAdditionalFields": {
+                            "type": "boolean",
+                            "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                            "default": true
                           },
                           "savePath": {
                             "type": "string",
@@ -5347,6 +5362,11 @@
                   "additionalProperties": true,
                   "default": {},
                   "properties": {}
+                },
+                "allowAdditionalFields": {
+                  "type": "boolean",
+                  "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                  "default": true
                 },
                 "savePath": {
                   "type": "string",

--- a/src/schemas/src_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/src_schemas/httpRequest_v2.schema.json
@@ -88,6 +88,11 @@
       "default": {},
       "properties": {}
     },
+    "allowAdditionalFields": {
+      "type": "boolean",
+      "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+      "default": true
+    },
     "savePath": {
       "type": "string",
       "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."


### PR DESCRIPTION
If `allowAdditionalFields` is set to `false`, the step fails if the response contains fields that aren't specified in `responseData`. Defaults to `true`. 