### PR TITLE
v1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.18.0-dev.2",
+  "version": "1.18.0-dev.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.18.0-dev.2",
+      "version": "1.18.0-dev.3",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.17.0",
+  "version": "1.18.0-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.17.0",
+      "version": "1.18.0-dev.2",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.18.0-dev.3",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.18.0-dev.3",
+      "version": "1.18.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.18.0-dev.3",
+  "version": "1.18.0",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.18.0-dev.2",
+  "version": "1.18.0-dev.3",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.17.0",
+  "version": "1.18.0-dev.2",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -821,6 +821,11 @@
                                     ],
                                     "default": "get"
                                   },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Timeout for the HTTP request, in milliseconds.",
+                                    "default": 60000
+                                  },
                                   "requestHeaders": {
                                     "description": "Headers to include in the HTTP request, in key/value format.",
                                     "type": "object",
@@ -934,6 +939,7 @@
                                     "action": "httpRequest",
                                     "url": "https://www.api-server.com",
                                     "method": "post",
+                                    "timeout": 30000,
                                     "requestHeaders": {
                                       "header": "value"
                                     },
@@ -1007,6 +1013,11 @@
                                     "type": "string",
                                     "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
                                   },
+                                  "timeout": {
+                                    "type": "integer",
+                                    "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
+                                    "default": 60000
+                                  },
                                   "setVariables": {
                                     "type": "array",
                                     "description": "Extract environment variables from the command's output.",
@@ -1063,6 +1074,7 @@
                                   {
                                     "action": "runShell",
                                     "command": "docker run hello-world",
+                                    "timeout": 20000,
                                     "exitCodes": [
                                       0
                                     ],

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -905,6 +905,11 @@
                                     "default": {},
                                     "properties": {}
                                   },
+                                  "allowAdditionalFields": {
+                                    "type": "boolean",
+                                    "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                                    "default": true
+                                  },
                                   "savePath": {
                                     "type": "string",
                                     "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -611,7 +611,7 @@
                                   },
                                   "matchText": {
                                     "type": "string",
-                                    "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                                    "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
                                   },
                                   "moveTo": {
                                     "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -663,6 +663,33 @@
                                         }
                                       }
                                     ]
+                                  },
+                                  "setVariables": {
+                                    "type": "array",
+                                    "description": "Extract environment variables from the element's text.",
+                                    "items": {
+                                      "oneOf": [
+                                        {
+                                          "description": "",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the environment variable to set.",
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "description": "Regex to extract the environment variable from the element's text.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "regex"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "default": []
                                   }
                                 },
                                 "required": [
@@ -700,6 +727,16 @@
                                       ],
                                       "delay": 100
                                     }
+                                  },
+                                  {
+                                    "action": "find",
+                                    "selector": "[title=ResultsCount]",
+                                    "setVariables": [
+                                      {
+                                        "name": "resultsCount",
+                                        "regex": ".*"
+                                      }
+                                    ]
                                   }
                                 ]
                               },

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -868,6 +868,31 @@
                                     "default": {},
                                     "properties": {}
                                   },
+                                  "savePath": {
+                                    "type": "string",
+                                    "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
+                                  },
+                                  "saveDirectory": {
+                                    "type": "string",
+                                    "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                                  },
+                                  "maxVariation": {
+                                    "type": "integer",
+                                    "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                                    "default": 0,
+                                    "minimum": 0,
+                                    "maximum": 100
+                                  },
+                                  "overwrite": {
+                                    "type": "string",
+                                    "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                                    "enum": [
+                                      "true",
+                                      "false",
+                                      "byVariation"
+                                    ],
+                                    "default": "false"
+                                  },
                                   "envsFromResponseData": {
                                     "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                                     "type": "array",
@@ -958,6 +983,27 @@
                                     "statusCodes": [
                                       200
                                     ]
+                                  },
+                                  {
+                                    "action": "httpRequest",
+                                    "url": "https://reqres.in/api/users",
+                                    "method": "post",
+                                    "requestData": {
+                                      "name": "morpheus",
+                                      "job": "leader"
+                                    },
+                                    "responseData": {
+                                      "name": "morpheus",
+                                      "job": "leader"
+                                    },
+                                    "statusCodes": [
+                                      200,
+                                      201
+                                    ],
+                                    "savePath": "response.json",
+                                    "saveDirectory": "media",
+                                    "maxVariation": 5,
+                                    "overwrite": "byVariation"
                                   }
                                 ]
                               },
@@ -1012,6 +1058,31 @@
                                   "output": {
                                     "type": "string",
                                     "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                                  },
+                                  "savePath": {
+                                    "type": "string",
+                                    "description": "File path to save the command's output, relative to `saveDirectory`."
+                                  },
+                                  "saveDirectory": {
+                                    "type": "string",
+                                    "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                                  },
+                                  "maxVariation": {
+                                    "type": "integer",
+                                    "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                                    "default": 0,
+                                    "minimum": 0,
+                                    "maximum": 100
+                                  },
+                                  "overwrite": {
+                                    "type": "string",
+                                    "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                                    "enum": [
+                                      "true",
+                                      "false",
+                                      "byVariation"
+                                    ],
+                                    "default": "false"
                                   },
                                   "timeout": {
                                     "type": "integer",
@@ -1103,6 +1174,18 @@
                                         "regex": ".*"
                                       }
                                     ]
+                                  },
+                                  {
+                                    "action": "runShell",
+                                    "command": "docker run hello-world",
+                                    "exitCodes": [
+                                      0
+                                    ],
+                                    "output": "Hello from Docker!",
+                                    "savePath": "docker-output.txt",
+                                    "saveDirectory": "output",
+                                    "maxVariation": 10,
+                                    "overwrite": "byVariation"
                                   }
                                 ]
                               },
@@ -1126,16 +1209,17 @@
                                   },
                                   "path": {
                                     "type": "string",
-                                    "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                                    "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                                     "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
                                   },
                                   "directory": {
                                     "type": "string",
-                                    "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                                    "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
                                   },
                                   "maxVariation": {
                                     "type": "number",
                                     "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                                    "default": 5,
                                     "minimum": 0,
                                     "maximum": 100
                                   },
@@ -1147,7 +1231,7 @@
                                       "false",
                                       "byVariation"
                                     ],
-                                    "default": false
+                                    "default": "false"
                                   }
                                 },
                                 "dynamicDefaults": {

--- a/src/schemas/output_schemas/find_v2.schema.json
+++ b/src/schemas/output_schemas/find_v2.schema.json
@@ -27,7 +27,7 @@
     },
     "matchText": {
       "type": "string",
-      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
     },
     "moveTo": {
       "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -79,6 +79,33 @@
           }
         }
       ]
+    },
+    "setVariables": {
+      "type": "array",
+      "description": "Extract environment variables from the element's text.",
+      "items": {
+        "oneOf": [
+          {
+            "description": "",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable to set.",
+                "type": "string"
+              },
+              "regex": {
+                "description": "Regex to extract the environment variable from the element's text.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "regex"
+            ]
+          }
+        ]
+      },
+      "default": []
     }
   },
   "required": [
@@ -116,6 +143,16 @@
         ],
         "delay": 100
       }
+    },
+    {
+      "action": "find",
+      "selector": "[title=ResultsCount]",
+      "setVariables": [
+        {
+          "name": "resultsCount",
+          "regex": ".*"
+        }
+      ]
     }
   ]
 }

--- a/src/schemas/output_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/output_schemas/httpRequest_v2.schema.json
@@ -101,6 +101,31 @@
       "default": {},
       "properties": {}
     },
+    "savePath": {
+      "type": "string",
+      "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
+    },
+    "saveDirectory": {
+      "type": "string",
+      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+    },
+    "maxVariation": {
+      "type": "integer",
+      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 100
+    },
+    "overwrite": {
+      "type": "string",
+      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+      "enum": [
+        "true",
+        "false",
+        "byVariation"
+      ],
+      "default": "false"
+    },
     "envsFromResponseData": {
       "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
       "type": "array",
@@ -191,6 +216,27 @@
       "statusCodes": [
         200
       ]
+    },
+    {
+      "action": "httpRequest",
+      "url": "https://reqres.in/api/users",
+      "method": "post",
+      "requestData": {
+        "name": "morpheus",
+        "job": "leader"
+      },
+      "responseData": {
+        "name": "morpheus",
+        "job": "leader"
+      },
+      "statusCodes": [
+        200,
+        201
+      ],
+      "savePath": "response.json",
+      "saveDirectory": "media",
+      "maxVariation": 5,
+      "overwrite": "byVariation"
     }
   ]
 }

--- a/src/schemas/output_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/output_schemas/httpRequest_v2.schema.json
@@ -101,6 +101,11 @@
       "default": {},
       "properties": {}
     },
+    "allowAdditionalFields": {
+      "type": "boolean",
+      "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+      "default": true
+    },
     "savePath": {
       "type": "string",
       "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."

--- a/src/schemas/output_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/output_schemas/httpRequest_v2.schema.json
@@ -54,6 +54,11 @@
       ],
       "default": "get"
     },
+    "timeout": {
+      "type": "integer",
+      "description": "Timeout for the HTTP request, in milliseconds.",
+      "default": 60000
+    },
     "requestHeaders": {
       "description": "Headers to include in the HTTP request, in key/value format.",
       "type": "object",
@@ -167,6 +172,7 @@
       "action": "httpRequest",
       "url": "https://www.api-server.com",
       "method": "post",
+      "timeout": 30000,
       "requestHeaders": {
         "header": "value"
       },

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -50,6 +50,31 @@
       "type": "string",
       "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
     },
+    "savePath": {
+      "type": "string",
+      "description": "File path to save the command's output, relative to `saveDirectory`."
+    },
+    "saveDirectory": {
+      "type": "string",
+      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+    },
+    "maxVariation": {
+      "type": "integer",
+      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 100
+    },
+    "overwrite": {
+      "type": "string",
+      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+      "enum": [
+        "true",
+        "false",
+        "byVariation"
+      ],
+      "default": "false"
+    },
     "timeout": {
       "type": "integer",
       "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
@@ -140,6 +165,18 @@
           "regex": ".*"
         }
       ]
+    },
+    {
+      "action": "runShell",
+      "command": "docker run hello-world",
+      "exitCodes": [
+        0
+      ],
+      "output": "Hello from Docker!",
+      "savePath": "docker-output.txt",
+      "saveDirectory": "output",
+      "maxVariation": 10,
+      "overwrite": "byVariation"
     }
   ]
 }

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -50,6 +50,11 @@
       "type": "string",
       "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
     },
+    "timeout": {
+      "type": "integer",
+      "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
+      "default": 60000
+    },
     "setVariables": {
       "type": "array",
       "description": "Extract environment variables from the command's output.",
@@ -106,6 +111,7 @@
     {
       "action": "runShell",
       "command": "docker run hello-world",
+      "timeout": 20000,
       "exitCodes": [
         0
       ],

--- a/src/schemas/output_schemas/saveScreenshot_v2.schema.json
+++ b/src/schemas/output_schemas/saveScreenshot_v2.schema.json
@@ -18,16 +18,17 @@
     },
     "path": {
       "type": "string",
-      "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+      "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
       "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
     },
     "directory": {
       "type": "string",
-      "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+      "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
     },
     "maxVariation": {
       "type": "number",
       "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+      "default": 5,
       "minimum": 0,
       "maximum": 100
     },
@@ -39,7 +40,7 @@
         "false",
         "byVariation"
       ],
-      "default": false
+      "default": "false"
     }
   },
   "dynamicDefaults": {

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -1165,7 +1165,7 @@
                         },
                         "matchText": {
                           "type": "string",
-                          "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                          "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
                         },
                         "moveTo": {
                           "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -1217,6 +1217,33 @@
                               }
                             }
                           ]
+                        },
+                        "setVariables": {
+                          "type": "array",
+                          "description": "Extract environment variables from the element's text.",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "description": "",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the environment variable to set.",
+                                    "type": "string"
+                                  },
+                                  "regex": {
+                                    "description": "Regex to extract the environment variable from the element's text.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "regex"
+                                ]
+                              }
+                            ]
+                          },
+                          "default": []
                         }
                       },
                       "required": [
@@ -1254,6 +1281,16 @@
                             ],
                             "delay": 100
                           }
+                        },
+                        {
+                          "action": "find",
+                          "selector": "[title=ResultsCount]",
+                          "setVariables": [
+                            {
+                              "name": "resultsCount",
+                              "regex": ".*"
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -544,6 +544,11 @@
                           "default": {},
                           "properties": {}
                         },
+                        "allowAdditionalFields": {
+                          "type": "boolean",
+                          "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                          "default": true
+                        },
                         "savePath": {
                           "type": "string",
                           "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -497,6 +497,11 @@
                           ],
                           "default": "get"
                         },
+                        "timeout": {
+                          "type": "integer",
+                          "description": "Timeout for the HTTP request, in milliseconds.",
+                          "default": 60000
+                        },
                         "requestHeaders": {
                           "description": "Headers to include in the HTTP request, in key/value format.",
                           "type": "object",
@@ -610,6 +615,7 @@
                           "action": "httpRequest",
                           "url": "https://www.api-server.com",
                           "method": "post",
+                          "timeout": 30000,
                           "requestHeaders": {
                             "header": "value"
                           },
@@ -683,6 +689,11 @@
                           "type": "string",
                           "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
                         },
+                        "timeout": {
+                          "type": "integer",
+                          "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
+                          "default": 60000
+                        },
                         "setVariables": {
                           "type": "array",
                           "description": "Extract environment variables from the command's output.",
@@ -739,6 +750,7 @@
                         {
                           "action": "runShell",
                           "command": "docker run hello-world",
+                          "timeout": 20000,
                           "exitCodes": [
                             0
                           ],

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -544,6 +544,31 @@
                           "default": {},
                           "properties": {}
                         },
+                        "savePath": {
+                          "type": "string",
+                          "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
+                        },
+                        "saveDirectory": {
+                          "type": "string",
+                          "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                        },
+                        "maxVariation": {
+                          "type": "integer",
+                          "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                          "default": 0,
+                          "minimum": 0,
+                          "maximum": 100
+                        },
+                        "overwrite": {
+                          "type": "string",
+                          "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                          "enum": [
+                            "true",
+                            "false",
+                            "byVariation"
+                          ],
+                          "default": "false"
+                        },
                         "envsFromResponseData": {
                           "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                           "type": "array",
@@ -634,6 +659,27 @@
                           "statusCodes": [
                             200
                           ]
+                        },
+                        {
+                          "action": "httpRequest",
+                          "url": "https://reqres.in/api/users",
+                          "method": "post",
+                          "requestData": {
+                            "name": "morpheus",
+                            "job": "leader"
+                          },
+                          "responseData": {
+                            "name": "morpheus",
+                            "job": "leader"
+                          },
+                          "statusCodes": [
+                            200,
+                            201
+                          ],
+                          "savePath": "response.json",
+                          "saveDirectory": "media",
+                          "maxVariation": 5,
+                          "overwrite": "byVariation"
                         }
                       ]
                     },
@@ -688,6 +734,31 @@
                         "output": {
                           "type": "string",
                           "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                        },
+                        "savePath": {
+                          "type": "string",
+                          "description": "File path to save the command's output, relative to `saveDirectory`."
+                        },
+                        "saveDirectory": {
+                          "type": "string",
+                          "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                        },
+                        "maxVariation": {
+                          "type": "integer",
+                          "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                          "default": 0,
+                          "minimum": 0,
+                          "maximum": 100
+                        },
+                        "overwrite": {
+                          "type": "string",
+                          "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                          "enum": [
+                            "true",
+                            "false",
+                            "byVariation"
+                          ],
+                          "default": "false"
                         },
                         "timeout": {
                           "type": "integer",
@@ -779,6 +850,18 @@
                               "regex": ".*"
                             }
                           ]
+                        },
+                        {
+                          "action": "runShell",
+                          "command": "docker run hello-world",
+                          "exitCodes": [
+                            0
+                          ],
+                          "output": "Hello from Docker!",
+                          "savePath": "docker-output.txt",
+                          "saveDirectory": "output",
+                          "maxVariation": 10,
+                          "overwrite": "byVariation"
                         }
                       ]
                     },
@@ -802,16 +885,17 @@
                         },
                         "path": {
                           "type": "string",
-                          "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                          "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                           "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
                         },
                         "directory": {
                           "type": "string",
-                          "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                          "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
                         },
                         "maxVariation": {
                           "type": "number",
                           "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                          "default": 5,
                           "minimum": 0,
                           "maximum": 100
                         },
@@ -823,7 +907,7 @@
                             "false",
                             "byVariation"
                           ],
-                          "default": false
+                          "default": "false"
                         }
                       },
                       "dynamicDefaults": {

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -353,6 +353,11 @@
                 ],
                 "default": "get"
               },
+              "timeout": {
+                "type": "integer",
+                "description": "Timeout for the HTTP request, in milliseconds.",
+                "default": 60000
+              },
               "requestHeaders": {
                 "description": "Headers to include in the HTTP request, in key/value format.",
                 "type": "object",
@@ -466,6 +471,7 @@
                 "action": "httpRequest",
                 "url": "https://www.api-server.com",
                 "method": "post",
+                "timeout": 30000,
                 "requestHeaders": {
                   "header": "value"
                 },
@@ -539,6 +545,11 @@
                 "type": "string",
                 "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
               },
+              "timeout": {
+                "type": "integer",
+                "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
+                "default": 60000
+              },
               "setVariables": {
                 "type": "array",
                 "description": "Extract environment variables from the command's output.",
@@ -595,6 +606,7 @@
               {
                 "action": "runShell",
                 "command": "docker run hello-world",
+                "timeout": 20000,
                 "exitCodes": [
                   0
                 ],

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -1021,7 +1021,7 @@
               },
               "matchText": {
                 "type": "string",
-                "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
               },
               "moveTo": {
                 "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -1073,6 +1073,33 @@
                     }
                   }
                 ]
+              },
+              "setVariables": {
+                "type": "array",
+                "description": "Extract environment variables from the element's text.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "description": "",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable to set.",
+                          "type": "string"
+                        },
+                        "regex": {
+                          "description": "Regex to extract the environment variable from the element's text.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "regex"
+                      ]
+                    }
+                  ]
+                },
+                "default": []
               }
             },
             "required": [
@@ -1110,6 +1137,16 @@
                   ],
                   "delay": 100
                 }
+              },
+              {
+                "action": "find",
+                "selector": "[title=ResultsCount]",
+                "setVariables": [
+                  {
+                    "name": "resultsCount",
+                    "regex": ".*"
+                  }
+                ]
               }
             ]
           },

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -400,6 +400,11 @@
                 "default": {},
                 "properties": {}
               },
+              "allowAdditionalFields": {
+                "type": "boolean",
+                "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                "default": true
+              },
               "savePath": {
                 "type": "string",
                 "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -400,6 +400,31 @@
                 "default": {},
                 "properties": {}
               },
+              "savePath": {
+                "type": "string",
+                "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
+              },
+              "saveDirectory": {
+                "type": "string",
+                "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+              },
+              "maxVariation": {
+                "type": "integer",
+                "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                "default": 0,
+                "minimum": 0,
+                "maximum": 100
+              },
+              "overwrite": {
+                "type": "string",
+                "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                "enum": [
+                  "true",
+                  "false",
+                  "byVariation"
+                ],
+                "default": "false"
+              },
               "envsFromResponseData": {
                 "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                 "type": "array",
@@ -490,6 +515,27 @@
                 "statusCodes": [
                   200
                 ]
+              },
+              {
+                "action": "httpRequest",
+                "url": "https://reqres.in/api/users",
+                "method": "post",
+                "requestData": {
+                  "name": "morpheus",
+                  "job": "leader"
+                },
+                "responseData": {
+                  "name": "morpheus",
+                  "job": "leader"
+                },
+                "statusCodes": [
+                  200,
+                  201
+                ],
+                "savePath": "response.json",
+                "saveDirectory": "media",
+                "maxVariation": 5,
+                "overwrite": "byVariation"
               }
             ]
           },
@@ -544,6 +590,31 @@
               "output": {
                 "type": "string",
                 "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+              },
+              "savePath": {
+                "type": "string",
+                "description": "File path to save the command's output, relative to `saveDirectory`."
+              },
+              "saveDirectory": {
+                "type": "string",
+                "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+              },
+              "maxVariation": {
+                "type": "integer",
+                "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                "default": 0,
+                "minimum": 0,
+                "maximum": 100
+              },
+              "overwrite": {
+                "type": "string",
+                "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                "enum": [
+                  "true",
+                  "false",
+                  "byVariation"
+                ],
+                "default": "false"
               },
               "timeout": {
                 "type": "integer",
@@ -635,6 +706,18 @@
                     "regex": ".*"
                   }
                 ]
+              },
+              {
+                "action": "runShell",
+                "command": "docker run hello-world",
+                "exitCodes": [
+                  0
+                ],
+                "output": "Hello from Docker!",
+                "savePath": "docker-output.txt",
+                "saveDirectory": "output",
+                "maxVariation": 10,
+                "overwrite": "byVariation"
               }
             ]
           },
@@ -658,16 +741,17 @@
               },
               "path": {
                 "type": "string",
-                "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                 "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
               },
               "directory": {
                 "type": "string",
-                "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
               },
               "maxVariation": {
                 "type": "number",
                 "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                "default": 5,
                 "minimum": 0,
                 "maximum": 100
               },
@@ -679,7 +763,7 @@
                   "false",
                   "byVariation"
                 ],
-                "default": false
+                "default": "false"
               }
             },
             "dynamicDefaults": {

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -949,6 +949,31 @@
                                       "default": {},
                                       "properties": {}
                                     },
+                                    "savePath": {
+                                      "type": "string",
+                                      "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
+                                    },
+                                    "saveDirectory": {
+                                      "type": "string",
+                                      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                                    },
+                                    "maxVariation": {
+                                      "type": "integer",
+                                      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                                      "default": 0,
+                                      "minimum": 0,
+                                      "maximum": 100
+                                    },
+                                    "overwrite": {
+                                      "type": "string",
+                                      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                                      "enum": [
+                                        "true",
+                                        "false",
+                                        "byVariation"
+                                      ],
+                                      "default": "false"
+                                    },
                                     "envsFromResponseData": {
                                       "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                                       "type": "array",
@@ -1039,6 +1064,27 @@
                                       "statusCodes": [
                                         200
                                       ]
+                                    },
+                                    {
+                                      "action": "httpRequest",
+                                      "url": "https://reqres.in/api/users",
+                                      "method": "post",
+                                      "requestData": {
+                                        "name": "morpheus",
+                                        "job": "leader"
+                                      },
+                                      "responseData": {
+                                        "name": "morpheus",
+                                        "job": "leader"
+                                      },
+                                      "statusCodes": [
+                                        200,
+                                        201
+                                      ],
+                                      "savePath": "response.json",
+                                      "saveDirectory": "media",
+                                      "maxVariation": 5,
+                                      "overwrite": "byVariation"
                                     }
                                   ]
                                 },
@@ -1093,6 +1139,31 @@
                                     "output": {
                                       "type": "string",
                                       "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                                    },
+                                    "savePath": {
+                                      "type": "string",
+                                      "description": "File path to save the command's output, relative to `saveDirectory`."
+                                    },
+                                    "saveDirectory": {
+                                      "type": "string",
+                                      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                                    },
+                                    "maxVariation": {
+                                      "type": "integer",
+                                      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                                      "default": 0,
+                                      "minimum": 0,
+                                      "maximum": 100
+                                    },
+                                    "overwrite": {
+                                      "type": "string",
+                                      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                                      "enum": [
+                                        "true",
+                                        "false",
+                                        "byVariation"
+                                      ],
+                                      "default": "false"
                                     },
                                     "timeout": {
                                       "type": "integer",
@@ -1184,6 +1255,18 @@
                                           "regex": ".*"
                                         }
                                       ]
+                                    },
+                                    {
+                                      "action": "runShell",
+                                      "command": "docker run hello-world",
+                                      "exitCodes": [
+                                        0
+                                      ],
+                                      "output": "Hello from Docker!",
+                                      "savePath": "docker-output.txt",
+                                      "saveDirectory": "output",
+                                      "maxVariation": 10,
+                                      "overwrite": "byVariation"
                                     }
                                   ]
                                 },
@@ -1207,16 +1290,17 @@
                                     },
                                     "path": {
                                       "type": "string",
-                                      "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                                      "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                                       "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
                                     },
                                     "directory": {
                                       "type": "string",
-                                      "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                                      "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
                                     },
                                     "maxVariation": {
                                       "type": "number",
                                       "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                                      "default": 5,
                                       "minimum": 0,
                                       "maximum": 100
                                     },
@@ -1228,7 +1312,7 @@
                                         "false",
                                         "byVariation"
                                       ],
-                                      "default": false
+                                      "default": "false"
                                     }
                                   },
                                   "dynamicDefaults": {
@@ -2600,6 +2684,31 @@
         "default": {},
         "properties": {}
       },
+      "savePath": {
+        "type": "string",
+        "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
+      },
+      "saveDirectory": {
+        "type": "string",
+        "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+      },
+      "maxVariation": {
+        "type": "integer",
+        "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+        "default": 0,
+        "minimum": 0,
+        "maximum": 100
+      },
+      "overwrite": {
+        "type": "string",
+        "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+        "enum": [
+          "true",
+          "false",
+          "byVariation"
+        ],
+        "default": "false"
+      },
       "envsFromResponseData": {
         "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
         "type": "array",
@@ -2690,6 +2799,27 @@
         "statusCodes": [
           200
         ]
+      },
+      {
+        "action": "httpRequest",
+        "url": "https://reqres.in/api/users",
+        "method": "post",
+        "requestData": {
+          "name": "morpheus",
+          "job": "leader"
+        },
+        "responseData": {
+          "name": "morpheus",
+          "job": "leader"
+        },
+        "statusCodes": [
+          200,
+          201
+        ],
+        "savePath": "response.json",
+        "saveDirectory": "media",
+        "maxVariation": 5,
+        "overwrite": "byVariation"
       }
     ]
   },
@@ -2843,6 +2973,31 @@
         "type": "string",
         "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
       },
+      "savePath": {
+        "type": "string",
+        "description": "File path to save the command's output, relative to `saveDirectory`."
+      },
+      "saveDirectory": {
+        "type": "string",
+        "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+      },
+      "maxVariation": {
+        "type": "integer",
+        "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+        "default": 0,
+        "minimum": 0,
+        "maximum": 100
+      },
+      "overwrite": {
+        "type": "string",
+        "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+        "enum": [
+          "true",
+          "false",
+          "byVariation"
+        ],
+        "default": "false"
+      },
       "timeout": {
         "type": "integer",
         "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
@@ -2933,6 +3088,18 @@
             "regex": ".*"
           }
         ]
+      },
+      {
+        "action": "runShell",
+        "command": "docker run hello-world",
+        "exitCodes": [
+          0
+        ],
+        "output": "Hello from Docker!",
+        "savePath": "docker-output.txt",
+        "saveDirectory": "output",
+        "maxVariation": 10,
+        "overwrite": "byVariation"
       }
     ]
   },
@@ -2956,16 +3123,17 @@
       },
       "path": {
         "type": "string",
-        "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+        "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
         "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
       },
       "directory": {
         "type": "string",
-        "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+        "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
       },
       "maxVariation": {
         "type": "number",
         "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+        "default": 5,
         "minimum": 0,
         "maximum": 100
       },
@@ -2977,7 +3145,7 @@
           "false",
           "byVariation"
         ],
-        "default": false
+        "default": "false"
       }
     },
     "dynamicDefaults": {
@@ -3681,6 +3849,31 @@
                             "default": {},
                             "properties": {}
                           },
+                          "savePath": {
+                            "type": "string",
+                            "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
+                          },
+                          "saveDirectory": {
+                            "type": "string",
+                            "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                          },
+                          "maxVariation": {
+                            "type": "integer",
+                            "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                            "default": 0,
+                            "minimum": 0,
+                            "maximum": 100
+                          },
+                          "overwrite": {
+                            "type": "string",
+                            "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                            "enum": [
+                              "true",
+                              "false",
+                              "byVariation"
+                            ],
+                            "default": "false"
+                          },
                           "envsFromResponseData": {
                             "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                             "type": "array",
@@ -3771,6 +3964,27 @@
                             "statusCodes": [
                               200
                             ]
+                          },
+                          {
+                            "action": "httpRequest",
+                            "url": "https://reqres.in/api/users",
+                            "method": "post",
+                            "requestData": {
+                              "name": "morpheus",
+                              "job": "leader"
+                            },
+                            "responseData": {
+                              "name": "morpheus",
+                              "job": "leader"
+                            },
+                            "statusCodes": [
+                              200,
+                              201
+                            ],
+                            "savePath": "response.json",
+                            "saveDirectory": "media",
+                            "maxVariation": 5,
+                            "overwrite": "byVariation"
                           }
                         ]
                       },
@@ -3825,6 +4039,31 @@
                           "output": {
                             "type": "string",
                             "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                          },
+                          "savePath": {
+                            "type": "string",
+                            "description": "File path to save the command's output, relative to `saveDirectory`."
+                          },
+                          "saveDirectory": {
+                            "type": "string",
+                            "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                          },
+                          "maxVariation": {
+                            "type": "integer",
+                            "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                            "default": 0,
+                            "minimum": 0,
+                            "maximum": 100
+                          },
+                          "overwrite": {
+                            "type": "string",
+                            "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                            "enum": [
+                              "true",
+                              "false",
+                              "byVariation"
+                            ],
+                            "default": "false"
                           },
                           "timeout": {
                             "type": "integer",
@@ -3916,6 +4155,18 @@
                                 "regex": ".*"
                               }
                             ]
+                          },
+                          {
+                            "action": "runShell",
+                            "command": "docker run hello-world",
+                            "exitCodes": [
+                              0
+                            ],
+                            "output": "Hello from Docker!",
+                            "savePath": "docker-output.txt",
+                            "saveDirectory": "output",
+                            "maxVariation": 10,
+                            "overwrite": "byVariation"
                           }
                         ]
                       },
@@ -3939,16 +4190,17 @@
                           },
                           "path": {
                             "type": "string",
-                            "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                            "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                             "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
                           },
                           "directory": {
                             "type": "string",
-                            "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                            "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
                           },
                           "maxVariation": {
                             "type": "number",
                             "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                            "default": 5,
                             "minimum": 0,
                             "maximum": 100
                           },
@@ -3960,7 +4212,7 @@
                               "false",
                               "byVariation"
                             ],
-                            "default": false
+                            "default": "false"
                           }
                         },
                         "dynamicDefaults": {
@@ -4985,6 +5237,31 @@
                   "default": {},
                   "properties": {}
                 },
+                "savePath": {
+                  "type": "string",
+                  "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
+                },
+                "saveDirectory": {
+                  "type": "string",
+                  "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                },
+                "maxVariation": {
+                  "type": "integer",
+                  "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "overwrite": {
+                  "type": "string",
+                  "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                  "enum": [
+                    "true",
+                    "false",
+                    "byVariation"
+                  ],
+                  "default": "false"
+                },
                 "envsFromResponseData": {
                   "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
                   "type": "array",
@@ -5075,6 +5352,27 @@
                   "statusCodes": [
                     200
                   ]
+                },
+                {
+                  "action": "httpRequest",
+                  "url": "https://reqres.in/api/users",
+                  "method": "post",
+                  "requestData": {
+                    "name": "morpheus",
+                    "job": "leader"
+                  },
+                  "responseData": {
+                    "name": "morpheus",
+                    "job": "leader"
+                  },
+                  "statusCodes": [
+                    200,
+                    201
+                  ],
+                  "savePath": "response.json",
+                  "saveDirectory": "media",
+                  "maxVariation": 5,
+                  "overwrite": "byVariation"
                 }
               ]
             },
@@ -5129,6 +5427,31 @@
                 "output": {
                   "type": "string",
                   "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
+                },
+                "savePath": {
+                  "type": "string",
+                  "description": "File path to save the command's output, relative to `saveDirectory`."
+                },
+                "saveDirectory": {
+                  "type": "string",
+                  "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+                },
+                "maxVariation": {
+                  "type": "integer",
+                  "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+                  "default": 0,
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "overwrite": {
+                  "type": "string",
+                  "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+                  "enum": [
+                    "true",
+                    "false",
+                    "byVariation"
+                  ],
+                  "default": "false"
                 },
                 "timeout": {
                   "type": "integer",
@@ -5220,6 +5543,18 @@
                       "regex": ".*"
                     }
                   ]
+                },
+                {
+                  "action": "runShell",
+                  "command": "docker run hello-world",
+                  "exitCodes": [
+                    0
+                  ],
+                  "output": "Hello from Docker!",
+                  "savePath": "docker-output.txt",
+                  "saveDirectory": "output",
+                  "maxVariation": 10,
+                  "overwrite": "byVariation"
                 }
               ]
             },
@@ -5243,16 +5578,17 @@
                 },
                 "path": {
                   "type": "string",
-                  "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+                  "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
                   "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
                 },
                 "directory": {
                   "type": "string",
-                  "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+                  "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
                 },
                 "maxVariation": {
                   "type": "number",
                   "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+                  "default": 5,
                   "minimum": 0,
                   "maximum": 100
                 },
@@ -5264,7 +5600,7 @@
                     "false",
                     "byVariation"
                   ],
-                  "default": false
+                  "default": "false"
                 }
               },
               "dynamicDefaults": {

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -902,6 +902,11 @@
                                       ],
                                       "default": "get"
                                     },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Timeout for the HTTP request, in milliseconds.",
+                                      "default": 60000
+                                    },
                                     "requestHeaders": {
                                       "description": "Headers to include in the HTTP request, in key/value format.",
                                       "type": "object",
@@ -1015,6 +1020,7 @@
                                       "action": "httpRequest",
                                       "url": "https://www.api-server.com",
                                       "method": "post",
+                                      "timeout": 30000,
                                       "requestHeaders": {
                                         "header": "value"
                                       },
@@ -1088,6 +1094,11 @@
                                       "type": "string",
                                       "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
                                     },
+                                    "timeout": {
+                                      "type": "integer",
+                                      "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
+                                      "default": 60000
+                                    },
                                     "setVariables": {
                                       "type": "array",
                                       "description": "Extract environment variables from the command's output.",
@@ -1144,6 +1155,7 @@
                                     {
                                       "action": "runShell",
                                       "command": "docker run hello-world",
+                                      "timeout": 20000,
                                       "exitCodes": [
                                         0
                                       ],
@@ -2541,6 +2553,11 @@
         ],
         "default": "get"
       },
+      "timeout": {
+        "type": "integer",
+        "description": "Timeout for the HTTP request, in milliseconds.",
+        "default": 60000
+      },
       "requestHeaders": {
         "description": "Headers to include in the HTTP request, in key/value format.",
         "type": "object",
@@ -2654,6 +2671,7 @@
         "action": "httpRequest",
         "url": "https://www.api-server.com",
         "method": "post",
+        "timeout": 30000,
         "requestHeaders": {
           "header": "value"
         },
@@ -2825,6 +2843,11 @@
         "type": "string",
         "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
       },
+      "timeout": {
+        "type": "integer",
+        "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
+        "default": 60000
+      },
       "setVariables": {
         "type": "array",
         "description": "Extract environment variables from the command's output.",
@@ -2881,6 +2904,7 @@
       {
         "action": "runShell",
         "command": "docker run hello-world",
+        "timeout": 20000,
         "exitCodes": [
           0
         ],
@@ -3610,6 +3634,11 @@
                             ],
                             "default": "get"
                           },
+                          "timeout": {
+                            "type": "integer",
+                            "description": "Timeout for the HTTP request, in milliseconds.",
+                            "default": 60000
+                          },
                           "requestHeaders": {
                             "description": "Headers to include in the HTTP request, in key/value format.",
                             "type": "object",
@@ -3723,6 +3752,7 @@
                             "action": "httpRequest",
                             "url": "https://www.api-server.com",
                             "method": "post",
+                            "timeout": 30000,
                             "requestHeaders": {
                               "header": "value"
                             },
@@ -3796,6 +3826,11 @@
                             "type": "string",
                             "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
                           },
+                          "timeout": {
+                            "type": "integer",
+                            "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
+                            "default": 60000
+                          },
                           "setVariables": {
                             "type": "array",
                             "description": "Extract environment variables from the command's output.",
@@ -3852,6 +3887,7 @@
                           {
                             "action": "runShell",
                             "command": "docker run hello-world",
+                            "timeout": 20000,
                             "exitCodes": [
                               0
                             ],
@@ -4902,6 +4938,11 @@
                   ],
                   "default": "get"
                 },
+                "timeout": {
+                  "type": "integer",
+                  "description": "Timeout for the HTTP request, in milliseconds.",
+                  "default": 60000
+                },
                 "requestHeaders": {
                   "description": "Headers to include in the HTTP request, in key/value format.",
                   "type": "object",
@@ -5015,6 +5056,7 @@
                   "action": "httpRequest",
                   "url": "https://www.api-server.com",
                   "method": "post",
+                  "timeout": 30000,
                   "requestHeaders": {
                     "header": "value"
                   },
@@ -5088,6 +5130,11 @@
                   "type": "string",
                   "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
                 },
+                "timeout": {
+                  "type": "integer",
+                  "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
+                  "default": 60000
+                },
                 "setVariables": {
                   "type": "array",
                   "description": "Extract environment variables from the command's output.",
@@ -5144,6 +5191,7 @@
                 {
                   "action": "runShell",
                   "command": "docker run hello-world",
+                  "timeout": 20000,
                   "exitCodes": [
                     0
                   ],

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -986,6 +986,11 @@
                                       "default": {},
                                       "properties": {}
                                     },
+                                    "allowAdditionalFields": {
+                                      "type": "boolean",
+                                      "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                                      "default": true
+                                    },
                                     "savePath": {
                                       "type": "string",
                                       "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
@@ -2758,6 +2763,11 @@
         "default": {},
         "properties": {}
       },
+      "allowAdditionalFields": {
+        "type": "boolean",
+        "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+        "default": true
+      },
       "savePath": {
         "type": "string",
         "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
@@ -3922,6 +3932,11 @@
                             "additionalProperties": true,
                             "default": {},
                             "properties": {}
+                          },
+                          "allowAdditionalFields": {
+                            "type": "boolean",
+                            "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                            "default": true
                           },
                           "savePath": {
                             "type": "string",
@@ -5347,6 +5362,11 @@
                   "additionalProperties": true,
                   "default": {},
                   "properties": {}
+                },
+                "allowAdditionalFields": {
+                  "type": "boolean",
+                  "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+                  "default": true
                 },
                 "savePath": {
                   "type": "string",

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -692,7 +692,7 @@
                                     },
                                     "matchText": {
                                       "type": "string",
-                                      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                                      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
                                     },
                                     "moveTo": {
                                       "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -744,6 +744,33 @@
                                           }
                                         }
                                       ]
+                                    },
+                                    "setVariables": {
+                                      "type": "array",
+                                      "description": "Extract environment variables from the element's text.",
+                                      "items": {
+                                        "oneOf": [
+                                          {
+                                            "description": "",
+                                            "type": "object",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the environment variable to set.",
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "description": "Regex to extract the environment variable from the element's text.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "regex"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "default": []
                                     }
                                   },
                                   "required": [
@@ -781,6 +808,16 @@
                                         ],
                                         "delay": 100
                                       }
+                                    },
+                                    {
+                                      "action": "find",
+                                      "selector": "[title=ResultsCount]",
+                                      "setVariables": [
+                                        {
+                                          "name": "resultsCount",
+                                          "regex": ".*"
+                                        }
+                                      ]
                                     }
                                   ]
                                 },
@@ -2427,7 +2464,7 @@
       },
       "matchText": {
         "type": "string",
-        "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+        "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
       },
       "moveTo": {
         "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -2479,6 +2516,33 @@
             }
           }
         ]
+      },
+      "setVariables": {
+        "type": "array",
+        "description": "Extract environment variables from the element's text.",
+        "items": {
+          "oneOf": [
+            {
+              "description": "",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Name of the environment variable to set.",
+                  "type": "string"
+                },
+                "regex": {
+                  "description": "Regex to extract the environment variable from the element's text.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "regex"
+              ]
+            }
+          ]
+        },
+        "default": []
       }
     },
     "required": [
@@ -2516,6 +2580,16 @@
           ],
           "delay": 100
         }
+      },
+      {
+        "action": "find",
+        "selector": "[title=ResultsCount]",
+        "setVariables": [
+          {
+            "name": "resultsCount",
+            "regex": ".*"
+          }
+        ]
       }
     ]
   },
@@ -4470,7 +4544,7 @@
                           },
                           "matchText": {
                             "type": "string",
-                            "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                            "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
                           },
                           "moveTo": {
                             "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -4522,6 +4596,33 @@
                                 }
                               }
                             ]
+                          },
+                          "setVariables": {
+                            "type": "array",
+                            "description": "Extract environment variables from the element's text.",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "description": "",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the environment variable to set.",
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "description": "Regex to extract the environment variable from the element's text.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "regex"
+                                  ]
+                                }
+                              ]
+                            },
+                            "default": []
                           }
                         },
                         "required": [
@@ -4559,6 +4660,16 @@
                               ],
                               "delay": 100
                             }
+                          },
+                          {
+                            "action": "find",
+                            "selector": "[title=ResultsCount]",
+                            "setVariables": [
+                              {
+                                "name": "resultsCount",
+                                "regex": ".*"
+                              }
+                            ]
                           }
                         ]
                       },
@@ -5858,7 +5969,7 @@
                 },
                 "matchText": {
                   "type": "string",
-                  "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+                  "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
                 },
                 "moveTo": {
                   "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -5910,6 +6021,33 @@
                       }
                     }
                   ]
+                },
+                "setVariables": {
+                  "type": "array",
+                  "description": "Extract environment variables from the element's text.",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "description": "",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the environment variable to set.",
+                            "type": "string"
+                          },
+                          "regex": {
+                            "description": "Regex to extract the environment variable from the element's text.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "regex"
+                        ]
+                      }
+                    ]
+                  },
+                  "default": []
                 }
               },
               "required": [
@@ -5947,6 +6085,16 @@
                     ],
                     "delay": 100
                   }
+                },
+                {
+                  "action": "find",
+                  "selector": "[title=ResultsCount]",
+                  "setVariables": [
+                    {
+                      "name": "resultsCount",
+                      "regex": ".*"
+                    }
+                  ]
                 }
               ]
             },

--- a/src/schemas/src_schemas/find_v2.schema.json
+++ b/src/schemas/src_schemas/find_v2.schema.json
@@ -27,7 +27,7 @@
     },
     "matchText": {
       "type": "string",
-      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails."
+      "description": "Text that the element should contain. If the element doesn't contain the text, the step fails. Accepts both strings an regular expressions. To use a regular expression, the expression should start and end with a `/`. For example, `/search/`."
     },
     "moveTo": {
       "description": "Move to the element. If the element isn't visible, it's scrolled into view. Only runs the if the test is being recorded.",
@@ -62,6 +62,30 @@
           }
         }
       ]
+    },
+    "setVariables": {
+      "type": "array",
+      "description": "Extract environment variables from the element's text.",
+      "items": {
+        "oneOf": [
+          {
+            "description": "",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable to set.",
+                "type": "string"
+              },
+              "regex": {
+                "description": "Regex to extract the environment variable from the element's text.",
+                "type": "string"
+              }
+            },
+            "required": ["name", "regex"]
+          }
+        ]
+      },
+      "default": []
     }
   },
   "required": ["action", "selector"],
@@ -94,6 +118,16 @@
         "keys": ["shorthair cat"],
         "delay": 100
       }
+    },
+    {
+      "action": "find",
+      "selector": "[title=ResultsCount]",
+      "setVariables": [
+        {
+          "name": "resultsCount",
+          "regex": ".*"
+        }
+      ]
     }
   ]
 }

--- a/src/schemas/src_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/src_schemas/httpRequest_v2.schema.json
@@ -41,6 +41,11 @@
       "transform": ["trim", "toEnumCase"],
       "default": "get"
     },
+    "timeout": {
+      "type": "integer",
+      "description": "Timeout for the HTTP request, in milliseconds.",
+      "default": 60000
+    },
     "requestHeaders": {
       "description": "Headers to include in the HTTP request, in key/value format.",
       "type": "object",
@@ -145,6 +150,7 @@
       "action": "httpRequest",
       "url": "https://www.api-server.com",
       "method": "post",
+      "timeout": 30000,
       "requestHeaders": {
         "header": "value"
       },

--- a/src/schemas/src_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/src_schemas/httpRequest_v2.schema.json
@@ -88,6 +88,31 @@
       "default": {},
       "properties": {}
     },
+    "savePath": {
+      "type": "string",
+      "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."
+    },
+    "saveDirectory": {
+      "type": "string",
+      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+    },
+    "maxVariation": {
+      "type": "integer",
+      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 100
+    },
+    "overwrite": {
+      "type": "string",
+      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+      "enum": [
+        "true",
+        "false",
+        "byVariation"
+      ],
+      "default": "false"
+    },
     "envsFromResponseData": {
       "description": "Environment variables to set based on response variables, as an object of the environment variable name and the jq filter applied to the response data to identify the variable's value.",
       "type": "array",
@@ -167,6 +192,24 @@
         "field": "value"
       },
       "statusCodes": [200]
+    },
+    {
+      "action": "httpRequest",
+      "url": "https://reqres.in/api/users",
+      "method": "post",
+      "requestData": {
+        "name": "morpheus",
+        "job": "leader"
+      },
+      "responseData": {
+        "name": "morpheus",
+        "job": "leader"
+      },
+      "statusCodes": [200, 201],
+      "savePath": "response.json",
+      "saveDirectory": "media",
+      "maxVariation": 5,
+      "overwrite": "byVariation"
     }
   ]
 }

--- a/src/schemas/src_schemas/httpRequest_v2.schema.json
+++ b/src/schemas/src_schemas/httpRequest_v2.schema.json
@@ -88,6 +88,11 @@
       "default": {},
       "properties": {}
     },
+    "allowAdditionalFields": {
+      "type": "boolean",
+      "description": "If `false`, the step fails when the response data contains fields not specified in `responseData`.",
+      "default": true
+    },
     "savePath": {
       "type": "string",
       "description": "File path to save the command's output, relative to `saveDirectory`. Specify a file extension that matches the expected response type, such as `.json` for JSON content or `.txt` for strings."

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -48,6 +48,31 @@
       "type": "string",
       "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
     },
+    "savePath": {
+      "type": "string",
+      "description": "File path to save the command's output, relative to `saveDirectory`."
+    },
+    "saveDirectory": {
+      "type": "string",
+      "description": "Directory to save the command's output. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
+    },
+    "maxVariation": {
+      "type": "integer",
+      "description": "Allowed variation in percentage of text different between the current output and previously saved output. If the difference between the current output and the previous output is greater than `maxVariation`, the step fails. If output doesn't exist at `savePath`, this value is ignored.",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 100
+    },
+    "overwrite": {
+      "type": "string",
+      "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
+      "enum": [
+        "true",
+        "false",
+        "byVariation"
+      ],
+      "default": "false"
+    },
     "timeout": {
       "type": "integer",
       "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
@@ -120,6 +145,16 @@
           "regex": ".*"
         }
       ]
+    },
+    {
+      "action": "runShell",
+      "command": "docker run hello-world",
+      "exitCodes": [0],
+      "output": "Hello from Docker!",
+      "savePath": "docker-output.txt",
+      "saveDirectory": "output",
+      "maxVariation": 10,
+      "overwrite": "byVariation"
     }
   ]
 }

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -48,6 +48,11 @@
       "type": "string",
       "description": "Content expected in the command's output. If the expected content can't be found in the command's output (either stdout or stderr), the step fails. Supports strings and regular expressions. To use a regular expression, the string must start and end with a forward slash, like in `/^hello-world.*/`."
     },
+    "timeout": {
+      "type": "integer",
+      "description": "Max time in milliseconds the command is allowed to run. If the command runs longer than this, the step fails.",
+      "default": 60000
+    },
     "setVariables": {
       "type": "array",
       "description": "Extract environment variables from the command's output.",
@@ -94,6 +99,7 @@
     {
       "action": "runShell",
       "command": "docker run hello-world",
+      "timeout": 20000,
       "exitCodes": [0],
       "output": "Hello from Docker!"
     },

--- a/src/schemas/src_schemas/saveScreenshot_v2.schema.json
+++ b/src/schemas/src_schemas/saveScreenshot_v2.schema.json
@@ -18,16 +18,17 @@
     },
     "path": {
       "type": "string",
-      "description": "Relative file path of the PNG file from `directory`. If not specified, the file name is the ID of the step.",
+      "description": "File path of the PNG file, relative to `directory`. If not specified, the file name is the ID of the step.",
       "pattern": "([A-Za-z0-9_-]*\\.(png|PNG)$|\\$[A-Za-z0-9_]+)"
     },
     "directory": {
       "type": "string",
-      "description": "Directory of the PNG file. Attempts to create the directory if it doesn't exist. If not specified, the directory is your media directory."
+      "description": "Directory of the PNG file. If the directory doesn't exist, creates the directory. If not specified, the directory is your media directory."
     },
     "maxVariation": {
       "type": "number",
       "description": "Allowed variation in percentage of pixels between the new screenshot and the exisitng screenshot at `path`. If the difference between the new screenshot and the existing screenshot is greater than `maxVariation`, the step fails. If a screenshot doesn't exist at `path`, this value is ignored.",
+      "default": 5,
       "minimum": 0,
       "maximum": 100
     },
@@ -39,7 +40,7 @@
         "false",
         "byVariation"
       ],
-      "default": false
+      "default": "false"
     }
   },
   "dynamicDefaults": {


### PR DESCRIPTION
- New `timeout` option for `runShell` and `httpRequest` actions. If an action exceeds its timeout, the step fails. Timeouts default to 1 minute.
- New `savePath`, `saveDirectory`, and `overwrite` options for `runShell` and `httpRequest`. Save the output of a command or request to file for future reference or to include in your docs!
- New `maxVariation` option for `runShell` and `httpRequest`. Much like screenshot diffing with `saveScreenshot`, this option compares command or response output against previous outputs and runs a percentage diff, failing the step if the diff is above the specified acceptable variation. Plays nice with the `overwrite` option's `byVariation` value.
- New `allowAdditionalFields` option for `httpRequest` actions. If `false`, fails the step if the actual response data contains fields that aren't specified in `responseData`, allowing for strict object matching. Defaults to `true`.
- `httpRequest` actions now return a `actualResponseData` field with the exact payload returned by the request. This mirrors `runShell` returning `stdout` and `stderr` values.
- `find`'s `matchText` can now match with regular expressions as well as strings. To specify a regular expression, begin and end the value with `/`.
- New `setVariables` option for the `find` action sets variables from an element's text value that match a regular expression. Same formatting and behavior as `runShell`'s `setVariables` option.