### PR TITLE
`workingDirectory` for `runShell`

### DIFF
--- a/src/resolvePaths.js
+++ b/src/resolvePaths.js
@@ -72,13 +72,13 @@ async function resolvePaths(
   let pathProperties;
   if (!nested && !objectType) {
     // Check if object matches the config schema
-    const validation = validate("config_v2", object);
+    const validation = validate("config_v2", { ...object });
     if (validation.valid) {
       pathProperties = configPaths;
       objectType = "config";
     } else {
       // Check if object matches the spec schema
-      const validation = validate("spec_v2", object);
+      const validation = validate("spec_v2", { ...object });
       if (validation.valid) {
         pathProperties = specPaths;
         objectType = "spec";

--- a/src/resolvePaths.js
+++ b/src/resolvePaths.js
@@ -41,6 +41,7 @@ async function resolvePaths(
     "cleanup",
     "savePath",
     "saveDirectory",
+    "workingDirectory",
   ];
 
   /**
@@ -52,6 +53,10 @@ async function resolvePaths(
    * @returns {string} - The resolved path.
    */
   function resolve(baseType, relativePath, filePath) {
+    // If path is already absolute, return it
+    if (path.isAbsolute(relativePath)) {
+      return relativePath;
+    }
     // If filePath is a file, use its directory as the base path
     filePath = fs.lstatSync(filePath).isFile()
       ? path.dirname(filePath)

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -1110,6 +1110,11 @@
                                     },
                                     "default": []
                                   },
+                                  "workingDirectory": {
+                                    "type": "string",
+                                    "description": "Working directory for the command.",
+                                    "default": "."
+                                  },
                                   "exitCodes": {
                                     "type": "array",
                                     "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -1247,6 +1252,7 @@
                                   {
                                     "action": "runShell",
                                     "command": "docker run hello-world",
+                                    "workingDirectory": ".",
                                     "exitCodes": [
                                       0
                                     ],

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -32,6 +32,11 @@
       },
       "default": []
     },
+    "workingDirectory": {
+      "type": "string",
+      "description": "Working directory for the command.",
+      "default": "."
+    },
     "exitCodes": {
       "type": "array",
       "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -169,6 +174,7 @@
     {
       "action": "runShell",
       "command": "docker run hello-world",
+      "workingDirectory": ".",
       "exitCodes": [
         0
       ],

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -722,6 +722,11 @@
                           },
                           "default": []
                         },
+                        "workingDirectory": {
+                          "type": "string",
+                          "description": "Working directory for the command.",
+                          "default": "."
+                        },
                         "exitCodes": {
                           "type": "array",
                           "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -859,6 +864,7 @@
                         {
                           "action": "runShell",
                           "command": "docker run hello-world",
+                          "workingDirectory": ".",
                           "exitCodes": [
                             0
                           ],

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -578,6 +578,11 @@
                 },
                 "default": []
               },
+              "workingDirectory": {
+                "type": "string",
+                "description": "Working directory for the command.",
+                "default": "."
+              },
               "exitCodes": {
                 "type": "array",
                 "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -715,6 +720,7 @@
               {
                 "action": "runShell",
                 "command": "docker run hello-world",
+                "workingDirectory": ".",
                 "exitCodes": [
                   0
                 ],

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -1191,6 +1191,11 @@
                                       },
                                       "default": []
                                     },
+                                    "workingDirectory": {
+                                      "type": "string",
+                                      "description": "Working directory for the command.",
+                                      "default": "."
+                                    },
                                     "exitCodes": {
                                       "type": "array",
                                       "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -1328,6 +1333,7 @@
                                     {
                                       "action": "runShell",
                                       "command": "docker run hello-world",
+                                      "workingDirectory": ".",
                                       "exitCodes": [
                                         0
                                       ],
@@ -3061,6 +3067,11 @@
         },
         "default": []
       },
+      "workingDirectory": {
+        "type": "string",
+        "description": "Working directory for the command.",
+        "default": "."
+      },
       "exitCodes": {
         "type": "array",
         "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -3198,6 +3209,7 @@
       {
         "action": "runShell",
         "command": "docker run hello-world",
+        "workingDirectory": ".",
         "exitCodes": [
           0
         ],
@@ -4133,6 +4145,11 @@
                             },
                             "default": []
                           },
+                          "workingDirectory": {
+                            "type": "string",
+                            "description": "Working directory for the command.",
+                            "default": "."
+                          },
                           "exitCodes": {
                             "type": "array",
                             "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -4270,6 +4287,7 @@
                           {
                             "action": "runShell",
                             "command": "docker run hello-world",
+                            "workingDirectory": ".",
                             "exitCodes": [
                               0
                             ],
@@ -5563,6 +5581,11 @@
                   },
                   "default": []
                 },
+                "workingDirectory": {
+                  "type": "string",
+                  "description": "Working directory for the command.",
+                  "default": "."
+                },
                 "exitCodes": {
                   "type": "array",
                   "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -5700,6 +5723,7 @@
                 {
                   "action": "runShell",
                   "command": "docker run hello-world",
+                  "workingDirectory": ".",
                   "exitCodes": [
                     0
                   ],

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -32,6 +32,11 @@
       },
       "default": []
     },
+    "workingDirectory": {
+      "type": "string",
+      "description": "Working directory for the command.",
+      "default": "."
+    },
     "exitCodes": {
       "type": "array",
       "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -149,6 +154,7 @@
     {
       "action": "runShell",
       "command": "docker run hello-world",
+      "workingDirectory": ".",
       "exitCodes": [0],
       "output": "Hello from Docker!",
       "savePath": "docker-output.txt",

--- a/src/validate.js
+++ b/src/validate.js
@@ -38,6 +38,7 @@ function validate(schemaKey, object) {
     const errors = check.errors.map((error) => error.message);
     result.errors = errors.join(", ");
   }
+  result.object = object;
 
   return result;
 }


### PR DESCRIPTION
`runShell` actions now support specifying the `workingDirectory` in which to run `command`. If the specified directory doesn't exist, falls back to the the directory Doc Detective was run in. As with other paths, `workingDirectory` is sensitive to the config's `relativePathBase` property, letting you specify whether the directory is relative to the current working directory or the file in which the directory is specified.