### PR TITLE
v1.19.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.19.1-dev.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.19.1-dev.0",
+      "version": "1.19.1",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.18.2",
+  "version": "1.19.1-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.18.2",
+      "version": "1.19.1-dev.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.19.1-dev.0",
+  "version": "1.19.1",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.18.2",
+  "version": "1.19.1-dev.0",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 const { schemas } = require("./schemas");
 const { validate } = require("./validate");
+const { resolvePaths } = require("./resolvePaths");
 
 exports.schemas = schemas;
 exports.validate = validate;
+exports.resolvePaths = resolvePaths;

--- a/src/resolvePaths.js
+++ b/src/resolvePaths.js
@@ -1,0 +1,115 @@
+const fs = require("fs");
+const path = require("path");
+const { validate } = require("./validate");
+
+exports.resolvePaths = resolvePaths;
+
+/**
+ * Resolves paths in config and spec objects based on the provided configuration, object type, object, and source file path.
+ *
+ * @param {object} config - The configuration object.
+ * @param {object} object - The object containing the paths to resolve.
+ * @param {string} filePath - The path of the file that contains the relative paths.
+ * @param {boolean} [nested=false] - Whether the object is nested within another object.
+ * @param {string} [objectType] - The type of object to resolve paths in ("config" or "spec"). Required if the object is nested.
+ * @returns {object} - The object with resolved paths.
+ */
+async function resolvePaths(
+  config,
+  object,
+  filePath,
+  nested = false,
+  objectType
+) {
+  // Config properties that contain paths
+  const configPaths = [
+    "input",
+    "output",
+    "envVariables",
+    "setup",
+    "cleanup",
+    "mediaDirectory",
+    "downloadDirectory",
+    "path",
+  ];
+  // Spec properties that contain paths
+  const specPaths = [
+    "file",
+    "path",
+    "directory",
+    "setup",
+    "cleanup",
+    "savePath",
+    "saveDirectory",
+  ];
+
+  /**
+   * Resolves a path based on the provided base type, relative path, and file path.
+   *
+   * @param {string} baseType - The base type of the path ("file" or "cwd").
+   * @param {string} relativePath - The relative path to resolve.
+   * @param {string} filePath - The file path to use as a reference.
+   * @returns {string} - The resolved path.
+   */
+  function resolve(baseType, relativePath, filePath) {
+    // If filePath is a file, use its directory as the base path
+    filePath = fs.lstatSync(filePath).isFile()
+      ? path.dirname(filePath)
+      : filePath;
+    // Resolve the path based on the base type
+    return baseType === "file"
+      ? path.resolve(filePath, relativePath)
+      : path.resolve(relativePath);
+  }
+
+  const relativePathBase = config.relativePathBase;
+  
+  let pathProperties;
+  if (!nested && !objectType) {
+    // Check if object matches the config schema
+    const validation = validate("config_v2", object);
+    if (validation.valid) {
+      pathProperties = configPaths;
+      objectType = "config";
+    } else {
+      // Check if object matches the spec schema
+      const validation = validate("spec_v2", object);
+      if (validation.valid) {
+        pathProperties = specPaths;
+        objectType = "spec";
+      } else {
+        throw new Error("Object isn't a valid config or spec.");
+      }
+    }
+  } else if (nested && !objectType) {
+    // If the object is nested, the object type is required
+    throw new Error("Object type is required for nested objects.");
+  } else if (objectType === "config") {
+    // If the object type is config, use configPaths
+    pathProperties = configPaths;
+  } else if (objectType === "spec") {
+    // If the object type is spec, use specPaths
+    pathProperties = specPaths;
+  }
+
+  for (const property of Object.keys(object)) {
+    if (typeof object[property] === "object") {
+      // If the property is an object, recursively call resolvePaths to resolve paths within the object
+      object[property] = await resolvePaths(
+        config,
+        object[property],
+        filePath,
+        true,
+        objectType
+      );
+    } else if (typeof object[property] === "string") {
+      // If the property is a string, check if it matches any of the path properties and resolve it if it does
+      pathProperties.forEach((path) => {
+        if (object[path]) {
+          object[path] = resolve(relativePathBase, object[path], filePath);
+        }
+      });
+    }
+  }
+  return object;
+}

--- a/src/resolvePaths.js
+++ b/src/resolvePaths.js
@@ -41,6 +41,7 @@ async function resolvePaths(
     "cleanup",
     "savePath",
     "saveDirectory",
+    "workingDirectory",
   ];
 
   /**
@@ -52,6 +53,10 @@ async function resolvePaths(
    * @returns {string} - The resolved path.
    */
   function resolve(baseType, relativePath, filePath) {
+    // If path is already absolute, return it
+    if (path.isAbsolute(relativePath)) {
+      return relativePath;
+    }
     // If filePath is a file, use its directory as the base path
     filePath = fs.lstatSync(filePath).isFile()
       ? path.dirname(filePath)
@@ -67,13 +72,13 @@ async function resolvePaths(
   let pathProperties;
   if (!nested && !objectType) {
     // Check if object matches the config schema
-    const validation = validate("config_v2", object);
+    const validation = validate("config_v2", { ...object });
     if (validation.valid) {
       pathProperties = configPaths;
       objectType = "config";
     } else {
       // Check if object matches the spec schema
-      const validation = validate("spec_v2", object);
+      const validation = validate("spec_v2", { ...object });
       if (validation.valid) {
         pathProperties = specPaths;
         objectType = "spec";

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -1092,6 +1092,11 @@
                                     },
                                     "default": []
                                   },
+                                  "workingDirectory": {
+                                    "type": "string",
+                                    "description": "Working directory for the command.",
+                                    "default": "."
+                                  },
                                   "exitCodes": {
                                     "type": "array",
                                     "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -1229,6 +1234,7 @@
                                   {
                                     "action": "runShell",
                                     "command": "docker run hello-world",
+                                    "workingDirectory": ".",
                                     "exitCodes": [
                                       0
                                     ],

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -455,24 +455,6 @@
                             "oneOf": [
                               {
                                 "type": "string"
-                              },
-                              {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                  "open": {
-                                    "description": "Pattern that matches the beginning of a multi-line markup instance. `open` patterns aren't included in the match.",
-                                    "type": "string"
-                                  },
-                                  "close": {
-                                    "description": "Pattern that matches the end of a multi-line markup instance. `close` patterns aren't included in the match.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "open",
-                                  "close"
-                                ]
                               }
                             ]
                           }

--- a/src/schemas/output_schemas/config_v2.schema.json
+++ b/src/schemas/output_schemas/config_v2.schema.json
@@ -41,6 +41,15 @@
       "description": "If `true` searches `input`, `setup`, and `cleanup` paths recursively for test specificaions and source files.",
       "type": "boolean"
     },
+    "relativePathBase": {
+      "description": "Whether paths should be interpreted as relative to the current working directory (`cwd`) or to the file in which they're specified (`file`).",
+      "type": "string",
+      "enum": [
+        "cwd",
+        "file"
+      ],
+      "default": "cwd"
+    },
     "envVariables": {
       "description": "Path to a `.env` file to load before performing a Doc Detective operation.",
       "type": "string"
@@ -158,7 +167,7 @@
                       },
                       "path": {
                         "type": "string",
-                        "description": "Path to the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
+                        "description": "Absolute path or command for the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
                       },
                       "options": {
                         "type": "object",
@@ -446,6 +455,24 @@
                             "oneOf": [
                               {
                                 "type": "string"
+                              },
+                              {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                  "open": {
+                                    "description": "Pattern that matches the beginning of a multi-line markup instance. `open` patterns aren't included in the match.",
+                                    "type": "string"
+                                  },
+                                  "close": {
+                                    "description": "Pattern that matches the end of a multi-line markup instance. `close` patterns aren't included in the match.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "open",
+                                  "close"
+                                ]
                               }
                             ]
                           }
@@ -1646,12 +1673,6 @@
               ]
             },
             {
-              "name": "codeBlock",
-              "regex": [
-                "(?=(```))(\\w|\\W)*(?<=```)"
-              ]
-            },
-            {
               "name": "interaction",
               "regex": [
                 "[cC]lick",
@@ -2032,6 +2053,7 @@
       ],
       "output": ".",
       "recursive": true,
+      "relativePathBase": "cwd",
       "logLevel": "info",
       "runTests": {
         "input": [

--- a/src/schemas/output_schemas/context_v2.schema.json
+++ b/src/schemas/output_schemas/context_v2.schema.json
@@ -23,7 +23,7 @@
         },
         "path": {
           "type": "string",
-          "description": "Path to the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
+          "description": "Absolute path or command for the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
         },
         "options": {
           "type": "object",

--- a/src/schemas/output_schemas/runShell_v2.schema.json
+++ b/src/schemas/output_schemas/runShell_v2.schema.json
@@ -32,6 +32,11 @@
       },
       "default": []
     },
+    "workingDirectory": {
+      "type": "string",
+      "description": "Working directory for the command.",
+      "default": "."
+    },
     "exitCodes": {
       "type": "array",
       "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -169,6 +174,7 @@
     {
       "action": "runShell",
       "command": "docker run hello-world",
+      "workingDirectory": ".",
       "exitCodes": [
         0
       ],

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -722,6 +722,11 @@
                           },
                           "default": []
                         },
+                        "workingDirectory": {
+                          "type": "string",
+                          "description": "Working directory for the command.",
+                          "default": "."
+                        },
                         "exitCodes": {
                           "type": "array",
                           "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -859,6 +864,7 @@
                         {
                           "action": "runShell",
                           "command": "docker run hello-world",
+                          "workingDirectory": ".",
                           "exitCodes": [
                             0
                           ],

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -44,7 +44,7 @@
                   },
                   "path": {
                     "type": "string",
-                    "description": "Path to the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
+                    "description": "Absolute path or command for the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
                   },
                   "options": {
                     "type": "object",
@@ -193,7 +193,7 @@
                             },
                             "path": {
                               "type": "string",
-                              "description": "Path to the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
+                              "description": "Absolute path or command for the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
                             },
                             "options": {
                               "type": "object",

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -49,7 +49,7 @@
                   },
                   "path": {
                     "type": "string",
-                    "description": "Path to the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
+                    "description": "Absolute path or command for the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
                   },
                   "options": {
                     "type": "object",

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -578,6 +578,11 @@
                 },
                 "default": []
               },
+              "workingDirectory": {
+                "type": "string",
+                "description": "Working directory for the command.",
+                "default": "."
+              },
               "exitCodes": {
                 "type": "array",
                 "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -715,6 +720,7 @@
               {
                 "action": "runShell",
                 "command": "docker run hello-world",
+                "workingDirectory": ".",
                 "exitCodes": [
                   0
                 ],

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -536,24 +536,6 @@
                               "oneOf": [
                                 {
                                   "type": "string"
-                                },
-                                {
-                                  "type": "object",
-                                  "additionalProperties": false,
-                                  "properties": {
-                                    "open": {
-                                      "description": "Pattern that matches the beginning of a multi-line markup instance. `open` patterns aren't included in the match.",
-                                      "type": "string"
-                                    },
-                                    "close": {
-                                      "description": "Pattern that matches the end of a multi-line markup instance. `close` patterns aren't included in the match.",
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "open",
-                                    "close"
-                                  ]
                                 }
                               ]
                             }

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -1173,6 +1173,11 @@
                                       },
                                       "default": []
                                     },
+                                    "workingDirectory": {
+                                      "type": "string",
+                                      "description": "Working directory for the command.",
+                                      "default": "."
+                                    },
                                     "exitCodes": {
                                       "type": "array",
                                       "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -1310,6 +1315,7 @@
                                     {
                                       "action": "runShell",
                                       "command": "docker run hello-world",
+                                      "workingDirectory": ".",
                                       "exitCodes": [
                                         0
                                       ],
@@ -3043,6 +3049,11 @@
         },
         "default": []
       },
+      "workingDirectory": {
+        "type": "string",
+        "description": "Working directory for the command.",
+        "default": "."
+      },
       "exitCodes": {
         "type": "array",
         "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -3180,6 +3191,7 @@
       {
         "action": "runShell",
         "command": "docker run hello-world",
+        "workingDirectory": ".",
         "exitCodes": [
           0
         ],
@@ -4115,6 +4127,11 @@
                             },
                             "default": []
                           },
+                          "workingDirectory": {
+                            "type": "string",
+                            "description": "Working directory for the command.",
+                            "default": "."
+                          },
                           "exitCodes": {
                             "type": "array",
                             "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -4252,6 +4269,7 @@
                           {
                             "action": "runShell",
                             "command": "docker run hello-world",
+                            "workingDirectory": ".",
                             "exitCodes": [
                               0
                             ],
@@ -5545,6 +5563,11 @@
                   },
                   "default": []
                 },
+                "workingDirectory": {
+                  "type": "string",
+                  "description": "Working directory for the command.",
+                  "default": "."
+                },
                 "exitCodes": {
                   "type": "array",
                   "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -5682,6 +5705,7 @@
                 {
                   "action": "runShell",
                   "command": "docker run hello-world",
+                  "workingDirectory": ".",
                   "exitCodes": [
                     0
                   ],

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -122,6 +122,15 @@
         "description": "If `true` searches `input`, `setup`, and `cleanup` paths recursively for test specificaions and source files.",
         "type": "boolean"
       },
+      "relativePathBase": {
+        "description": "Whether paths should be interpreted as relative to the current working directory (`cwd`) or to the file in which they're specified (`file`).",
+        "type": "string",
+        "enum": [
+          "cwd",
+          "file"
+        ],
+        "default": "cwd"
+      },
       "envVariables": {
         "description": "Path to a `.env` file to load before performing a Doc Detective operation.",
         "type": "string"
@@ -239,7 +248,7 @@
                         },
                         "path": {
                           "type": "string",
-                          "description": "Path to the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
+                          "description": "Absolute path or command for the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
                         },
                         "options": {
                           "type": "object",
@@ -527,6 +536,24 @@
                               "oneOf": [
                                 {
                                   "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "open": {
+                                      "description": "Pattern that matches the beginning of a multi-line markup instance. `open` patterns aren't included in the match.",
+                                      "type": "string"
+                                    },
+                                    "close": {
+                                      "description": "Pattern that matches the end of a multi-line markup instance. `close` patterns aren't included in the match.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "open",
+                                    "close"
+                                  ]
                                 }
                               ]
                             }
@@ -1727,12 +1754,6 @@
                 ]
               },
               {
-                "name": "codeBlock",
-                "regex": [
-                  "(?=(```))(\\w|\\W)*(?<=```)"
-                ]
-              },
-              {
                 "name": "interaction",
                 "regex": [
                   "[cC]lick",
@@ -2113,6 +2134,7 @@
         ],
         "output": ".",
         "recursive": true,
+        "relativePathBase": "cwd",
         "logLevel": "info",
         "runTests": {
           "input": [
@@ -2351,7 +2373,7 @@
           },
           "path": {
             "type": "string",
-            "description": "Path to the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
+            "description": "Absolute path or command for the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
           },
           "options": {
             "type": "object",
@@ -3433,7 +3455,7 @@
                     },
                     "path": {
                       "type": "string",
-                      "description": "Path to the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
+                      "description": "Absolute path or command for the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
                     },
                     "options": {
                       "type": "object",
@@ -3582,7 +3604,7 @@
                               },
                               "path": {
                                 "type": "string",
-                                "description": "Path to the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
+                                "description": "Absolute path or command for the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
                               },
                               "options": {
                                 "type": "object",
@@ -5012,7 +5034,7 @@
                     },
                     "path": {
                       "type": "string",
-                      "description": "Path to the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
+                      "description": "Absolute path or command for the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
                     },
                     "options": {
                       "type": "object",

--- a/src/schemas/src_schemas/config_v2.schema.json
+++ b/src/schemas/src_schemas/config_v2.schema.json
@@ -21,6 +21,12 @@
       "default": true,
       "$ref": "#/definitions/recursive"
     },
+    "relativePathBase": {
+      "description": "Whether paths should be interpreted as relative to the current working directory (`cwd`) or to the file in which they're specified (`file`).",
+      "type": "string",
+      "enum": ["cwd", "file"],
+      "default": "cwd"
+    },
     "envVariables": {
       "description": "Path to a `.env` file to load before performing a Doc Detective operation.",
       "type": "string"
@@ -241,6 +247,21 @@
                             "oneOf": [
                               {
                                 "type": "string"
+                              },
+                              {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                  "open": {
+                                    "description": "Pattern that matches the beginning of a multi-line markup instance. `open` patterns aren't included in the match.",
+                                    "type": "string"
+                                  },
+                                  "close": {
+                                    "description": "Pattern that matches the end of a multi-line markup instance. `close` patterns aren't included in the match.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["open", "close"]
                               }
                             ]
                           }
@@ -383,7 +404,9 @@
             },
             {
               "name": "navigationLink",
-              "regex": ["(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"],
+              "regex": [
+                "(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"
+              ],
               "actions": ["goTo"]
             },
             {
@@ -397,10 +420,6 @@
             {
               "name": "codeInline",
               "regex": ["(?<!`)`(?!`).+?(?<!`)`(?!`)"]
-            },
-            {
-              "name": "codeBlock",
-              "regex": ["(?=(```))(\\w|\\W)*(?<=```)"]
             },
             {
               "name": "interaction",
@@ -644,7 +663,9 @@
             },
             {
               "name": "navigationLink",
-              "regex": ["(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"],
+              "regex": [
+                "(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"
+              ],
               "actions": ["goTo"]
             },
             {
@@ -726,6 +747,7 @@
       "input": ["."],
       "output": ".",
       "recursive": true,
+      "relativePathBase": "cwd",
       "logLevel": "info",
       "runTests": {
         "input": ["."],
@@ -787,7 +809,9 @@
             },
             {
               "name": "navigationLink",
-              "regex": ["(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"],
+              "regex": [
+                "(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)"
+              ],
               "actions": ["goTo"]
             },
             {

--- a/src/schemas/src_schemas/config_v2.schema.json
+++ b/src/schemas/src_schemas/config_v2.schema.json
@@ -247,21 +247,6 @@
                             "oneOf": [
                               {
                                 "type": "string"
-                              },
-                              {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                  "open": {
-                                    "description": "Pattern that matches the beginning of a multi-line markup instance. `open` patterns aren't included in the match.",
-                                    "type": "string"
-                                  },
-                                  "close": {
-                                    "description": "Pattern that matches the end of a multi-line markup instance. `close` patterns aren't included in the match.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": ["open", "close"]
                               }
                             ]
                           }

--- a/src/schemas/src_schemas/context_v2.schema.json
+++ b/src/schemas/src_schemas/context_v2.schema.json
@@ -16,7 +16,7 @@
         },
         "path": {
           "type": "string",
-          "description": "Path to the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
+          "description": "Absolute path or command for the application. If not specified, defaults to typical install paths per platform. If specified but the path is invalid, the context is skipped."
         },
         "options": {
           "type": "object",

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -32,6 +32,11 @@
       },
       "default": []
     },
+    "workingDirectory": {
+      "type": "string",
+      "description": "Working directory for the command.",
+      "default": "."
+    },
     "exitCodes": {
       "type": "array",
       "description": "Expected exit codes of the command. If the command's actual exit code isn't in this list, the step fails.",
@@ -149,6 +154,7 @@
     {
       "action": "runShell",
       "command": "docker run hello-world",
+      "workingDirectory": ".",
       "exitCodes": [0],
       "output": "Hello from Docker!",
       "savePath": "docker-output.txt",

--- a/src/validate.js
+++ b/src/validate.js
@@ -38,6 +38,7 @@ function validate(schemaKey, object) {
     const errors = check.errors.map((error) => error.message);
     result.errors = errors.join(", ");
   }
+  result.object = object;
 
   return result;
 }


### PR DESCRIPTION
- New config `relativePathBase` property specifies whether relative paths are resolved from the current working directory (`cwd`) or from the file that the path was specified in (`file`).
- `runShell` actions now support specifying the `workingDirectory` in which to run `command`. If the specified directory doesn't exist, falls back to the the directory Doc Detective was run in. As with other paths, `workingDirectory` is sensitive to the config's `relativePathBase` property, letting you specify whether the directory is relative to the current working directory or the file in which the directory is specified.