### PR TITLE
Add onStepFail field to test schemas for handling step failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "1.21.1-dev.0",
+  "version": "1.21.1-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "1.21.1-dev.0",
+      "version": "1.21.1-dev.2",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "1.21.1-dev.0",
+  "version": "1.21.1-dev.2",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/src/schemas/output_schemas/spec_v2.schema.json
+++ b/src/schemas/output_schemas/spec_v2.schema.json
@@ -483,6 +483,16 @@
                 "type": "string",
                 "description": "Path to a test specification to perform after this test, while maintaining this test's context. Useful for cleaning up testing environments. Only the `steps` property is used from the first test in the cleanup spec."
               },
+              "onStepFail": {
+                "type": "string",
+                "description": "**Note**: This field is in beta and subject to change.<br/><br/>Action to take on the workflow when a step fails.",
+                "enum": [
+                  "continue",
+                  "stop"
+                ],
+                "default": "stop",
+                "readOnly": true
+              },
               "steps": {
                 "description": "Actions to perform as part of the test. Performed in the sequence defined. If one or more actions fail, the test fails.",
                 "type": "array",
@@ -1811,6 +1821,7 @@
                 ],
                 "setup": "setup.json",
                 "cleanup": "cleanup.json",
+                "onStepFail": "stop",
                 "steps": [
                   {
                     "action": "setVariables",

--- a/src/schemas/output_schemas/test_v2.schema.json
+++ b/src/schemas/output_schemas/test_v2.schema.json
@@ -244,6 +244,16 @@
       "type": "string",
       "description": "Path to a test specification to perform after this test, while maintaining this test's context. Useful for cleaning up testing environments. Only the `steps` property is used from the first test in the cleanup spec."
     },
+    "onStepFail": {
+      "type": "string",
+      "description": "**Note**: This field is in beta and subject to change.<br/><br/>Action to take on the workflow when a step fails.",
+      "enum": [
+        "continue",
+        "stop"
+      ],
+      "default": "stop",
+      "readOnly": true
+    },
     "steps": {
       "description": "Actions to perform as part of the test. Performed in the sequence defined. If one or more actions fail, the test fails.",
       "type": "array",
@@ -1572,6 +1582,7 @@
       ],
       "setup": "setup.json",
       "cleanup": "cleanup.json",
+      "onStepFail": "stop",
       "steps": [
         {
           "action": "setVariables",

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -4508,6 +4508,16 @@
                   "type": "string",
                   "description": "Path to a test specification to perform after this test, while maintaining this test's context. Useful for cleaning up testing environments. Only the `steps` property is used from the first test in the cleanup spec."
                 },
+                "onStepFail": {
+                  "type": "string",
+                  "description": "**Note**: This field is in beta and subject to change.<br/><br/>Action to take on the workflow when a step fails.",
+                  "enum": [
+                    "continue",
+                    "stop"
+                  ],
+                  "default": "stop",
+                  "readOnly": true
+                },
                 "steps": {
                   "description": "Actions to perform as part of the test. Performed in the sequence defined. If one or more actions fail, the test fails.",
                   "type": "array",
@@ -5836,6 +5846,7 @@
                   ],
                   "setup": "setup.json",
                   "cleanup": "cleanup.json",
+                  "onStepFail": "stop",
                   "steps": [
                     {
                       "action": "setVariables",
@@ -6303,6 +6314,16 @@
       "cleanup": {
         "type": "string",
         "description": "Path to a test specification to perform after this test, while maintaining this test's context. Useful for cleaning up testing environments. Only the `steps` property is used from the first test in the cleanup spec."
+      },
+      "onStepFail": {
+        "type": "string",
+        "description": "**Note**: This field is in beta and subject to change.<br/><br/>Action to take on the workflow when a step fails.",
+        "enum": [
+          "continue",
+          "stop"
+        ],
+        "default": "stop",
+        "readOnly": true
       },
       "steps": {
         "description": "Actions to perform as part of the test. Performed in the sequence defined. If one or more actions fail, the test fails.",
@@ -7632,6 +7653,7 @@
         ],
         "setup": "setup.json",
         "cleanup": "cleanup.json",
+        "onStepFail": "stop",
         "steps": [
           {
             "action": "setVariables",

--- a/src/schemas/src_schemas/test_v2.schema.json
+++ b/src/schemas/src_schemas/test_v2.schema.json
@@ -58,6 +58,13 @@
       "type": "string",
       "description": "Path to a test specification to perform after this test, while maintaining this test's context. Useful for cleaning up testing environments. Only the `steps` property is used from the first test in the cleanup spec."
     },
+    "onStepFail": {
+      "type": "string",
+      "description": "**Note**: This field is in beta and subject to change.<br/><br/>Action to take on the workflow when a step fails.",
+      "enum": ["continue", "stop"],
+      "default": "stop",
+      "readOnly": true
+    },
     "steps": {
       "description": "Actions to perform as part of the test. Performed in the sequence defined. If one or more actions fail, the test fails.",
       "type": "array",
@@ -123,6 +130,7 @@
       ],
       "setup": "setup.json",
       "cleanup": "cleanup.json",
+      "onStepFail": "stop",
       "steps": [
         {
           "action": "setVariables",


### PR DESCRIPTION
Introduce an `onStepFail` field to the test schemas, allowing users to specify actions to take when a step fails. This field is currently in beta and offers options to either continue or stop the workflow.