### PR TITLE
Add new fields to `test_v2.schema.json` to enhance test result reporting

### DIFF
--- a/src/schemas/src_schemas/test_v2.schema.json
+++ b/src/schemas/src_schemas/test_v2.schema.json
@@ -77,6 +77,65 @@
           { "$ref": "wait_v2.schema.json#" }
         ]
       }
+    },
+    "outputs": {
+      "type": "object",
+      "description": "User-specified output values.",
+      "readOnly": true
+    },
+    "errors": {
+      "type": "array",
+      "description": "Errors the spec ran into during the run.",
+      "readOnly": true,
+      "items": {
+        "type": "object",
+        "required": ["message", "code", "timestamp"],
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Description of the error."
+          },
+          "code": {
+            "type": "string",
+            "description": "Unique error code, if applicable."
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Time the error occurred, in ISO 8601 format."
+          },
+          "details": {
+            "type": "object",
+            "description": "Additional details about the error, such as stack traces or specific error data."
+          }
+        }
+      }
+    },
+    "startTime": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the test started.",
+      "readOnly": true
+    },
+    "duration": {
+      "type": "integer",
+      "description": "Duration of the test in milliseconds.",
+      "readOnly": true
+    },
+    "stepsTotal": {
+      "type": "integer",
+      "description": "Total number of steps in the test.",
+      "readOnly": true
+    },
+    "stepsPassed": {
+      "type": "integer",
+      "description": "Number of steps that passed in the test.",
+      "readOnly": true
+    },
+    "stepsFailed": {
+      "type": "integer",
+      "description": "Number of steps that failed in the test.",
+      "readOnly": true
     }
   },
   "dynamicDefaults": {
@@ -195,5 +254,5 @@
         }
       ]
     }
-]
+  ]
 }


### PR DESCRIPTION
This pull request adds several new properties to the `test_v2.schema.json` file to enhance the schema with additional metadata and error handling capabilities.

Enhancements to schema:

* Added `outputs` property to store user-specified output values.
* Added `errors` property to capture errors encountered during the test run, including message, code, timestamp, and additional details.
* Added `startTime` property to record the timestamp when the test started.
* Added `duration` property to indicate the duration of the test in milliseconds.
* Added properties `stepsTotal`, `stepsPassed`, and `stepsFailed` to track the total number of steps, as well as the number of steps that passed and failed in the test.