### PR TITLE
Add read-only element object to find_v2.schema.json

### DIFF
--- a/src/schemas/src_schemas/find_v2.schema.json
+++ b/src/schemas/src_schemas/find_v2.schema.json
@@ -86,6 +86,66 @@
         ]
       },
       "default": []
+    },
+    "element": {
+      "type": "object",
+      "description": "Details of the found element.",
+      "readOnly": true,
+      "properties": {
+        "tagName": {
+          "type": "string",
+          "description": "The tag name of the element."
+        },
+        "attributes": {
+          "type": "object",
+          "description": "An object containing the element's attributes and their values."
+        },
+        "cssClasses": {
+          "type": "array",
+          "description": "An array of CSS classes applied to the element.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "type": "string",
+          "description": "The id attribute of the element, if present."
+        },
+        "boundingBox": {
+          "type": "object",
+          "description": "An object containing the element's position and dimensions.",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "width": {
+              "type": "number"
+            },
+            "height": {
+              "type": "number"
+            }
+          }
+        },
+        "isDisplayed": {
+          "type": "boolean",
+          "description": "A boolean indicating whether the element is currently displayed on the page."
+        },
+        "isEnabled": {
+          "type": "boolean",
+          "description": "A boolean indicating whether the element is enabled and can be interacted with."
+        },
+        "isSelected": {
+          "type": "boolean",
+          "description": "A boolean indicating whether the element is selected."
+        },
+        "text": {
+          "type": "string",
+          "description": "The text content of the element."
+        }
+      }
     }
   },
   "required": ["action", "selector"],

--- a/src/schemas/src_schemas/find_v2.schema.json
+++ b/src/schemas/src_schemas/find_v2.schema.json
@@ -87,63 +87,75 @@
       },
       "default": []
     },
-    "element": {
+    "outputs": {
       "type": "object",
-      "description": "Details of the found element.",
-      "readOnly": true,
+      "description": "Outputs from step processes and user-defined expressions. Use the `outputs` object to reference outputs in subsequent steps. If a user-defined output matches the key for a step-defined output, the user-defined output takes precedence.",
+      "patternProperties": {
+        "^[A-Za-z0-9_]+$": {
+          "type": "string",
+          "description": "Runtime expression for a user-defined output value."
+        }
+      },
       "properties": {
-        "tagName": {
-          "type": "string",
-          "description": "The tag name of the element."
-        },
-        "attributes": {
+        "element": {
           "type": "object",
-          "description": "An object containing the element's attributes and their values."
-        },
-        "cssClasses": {
-          "type": "array",
-          "description": "An array of CSS classes applied to the element.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "id": {
-          "type": "string",
-          "description": "The id attribute of the element, if present."
-        },
-        "boundingBox": {
-          "type": "object",
-          "description": "An object containing the element's position and dimensions.",
+          "description": "Details of the found element.",
+          "readOnly": true,
           "properties": {
-            "x": {
-              "type": "number"
+            "tagName": {
+              "type": "string",
+              "description": "The tag name of the element."
             },
-            "y": {
-              "type": "number"
+            "attributes": {
+              "type": "object",
+              "description": "An object containing the element's attributes and their values."
             },
-            "width": {
-              "type": "number"
+            "cssClasses": {
+              "type": "array",
+              "description": "An array of CSS classes applied to the element.",
+              "items": {
+                "type": "string"
+              }
             },
-            "height": {
-              "type": "number"
+            "id": {
+              "type": "string",
+              "description": "The id attribute of the element, if present."
+            },
+            "boundingBox": {
+              "type": "object",
+              "description": "An object containing the element's position and dimensions.",
+              "properties": {
+                "x": {
+                  "type": "number"
+                },
+                "y": {
+                  "type": "number"
+                },
+                "width": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                }
+              }
+            },
+            "isDisplayed": {
+              "type": "boolean",
+              "description": "A boolean indicating whether the element is currently displayed on the page."
+            },
+            "isEnabled": {
+              "type": "boolean",
+              "description": "A boolean indicating whether the element is enabled and can be interacted with."
+            },
+            "isSelected": {
+              "type": "boolean",
+              "description": "A boolean indicating whether the element is selected."
+            },
+            "text": {
+              "type": "string",
+              "description": "The text content of the element."
             }
           }
-        },
-        "isDisplayed": {
-          "type": "boolean",
-          "description": "A boolean indicating whether the element is currently displayed on the page."
-        },
-        "isEnabled": {
-          "type": "boolean",
-          "description": "A boolean indicating whether the element is enabled and can be interacted with."
-        },
-        "isSelected": {
-          "type": "boolean",
-          "description": "A boolean indicating whether the element is selected."
-        },
-        "text": {
-          "type": "string",
-          "description": "The text content of the element."
         }
       }
     }


### PR DESCRIPTION
Add read-only `element` object with details of the found element to `find_v2.schema.json`.

* Add `element` object to the `properties` section with details of the found element.
* Include properties like `tagName`, `attributes`, `cssClasses`, `id`, `boundingBox`, `isDisplayed`, `isEnabled`, `isSelected`, and `text`.
* Mark the `element` object as read-only.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/doc-detective/doc-detective-common/pull/70?shareId=6182be10-c7c4-4f95-881d-f316d9938194).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the "find" action schema with a new "outputs" property, allowing for user-defined expressions and detailed information about found elements, including attributes, CSS classes, dimensions, and display status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->