### PR TITLE
Add read-only stdout, stderr, and exitCode properties to runShell_v2.schema.json

### DIFF
--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -106,6 +106,21 @@
         ]
       },
       "default": []
+    },
+    "stdout": {
+      "type": "string",
+      "description": "Standard output of the command.",
+      "readOnly": true
+    },
+    "stderr": {
+      "type": "string",
+      "description": "Standard error of the command.",
+      "readOnly": true
+    },
+    "exitCode": {
+      "type": "integer",
+      "description": "Exit code of the command.",
+      "readOnly": true
     }
   },
   "dynamicDefaults": {

--- a/src/schemas/src_schemas/runShell_v2.schema.json
+++ b/src/schemas/src_schemas/runShell_v2.schema.json
@@ -71,11 +71,7 @@
     "overwrite": {
       "type": "string",
       "description": "If `true`, overwrites the existing output at `savePath` if it exists.\nIf `byVariation`, overwrites the existing output at `savePath` if the difference between the new output and the existing output is greater than `maxVariation`.",
-      "enum": [
-        "true",
-        "false",
-        "byVariation"
-      ],
+      "enum": ["true", "false", "byVariation"],
       "default": "false"
     },
     "timeout": {
@@ -107,20 +103,32 @@
       },
       "default": []
     },
-    "stdout": {
-      "type": "string",
-      "description": "Standard output of the command.",
-      "readOnly": true
-    },
-    "stderr": {
-      "type": "string",
-      "description": "Standard error of the command.",
-      "readOnly": true
-    },
-    "exitCode": {
-      "type": "integer",
-      "description": "Exit code of the command.",
-      "readOnly": true
+    "outputs": {
+      "type": "object",
+      "description": "Outputs from step processes and user-defined expressions. Use the `outputs` object to reference outputs in subsequent steps. If a user-defined output matches the key for a step-defined output, the user-defined output takes precedence.",
+      "patternProperties": {
+        "^[A-Za-z0-9_]+$": {
+          "type": "string",
+          "description": "Runtime expression for a user-defined output value."
+        }
+      },
+      "properties": {
+        "stdout": {
+          "type": "string",
+          "description": "Standard output of the command.",
+          "readOnly": true
+        },
+        "stderr": {
+          "type": "string",
+          "description": "Standard error of the command.",
+          "readOnly": true
+        },
+        "exitCode": {
+          "type": "integer",
+          "description": "Exit code of the command.",
+          "readOnly": true
+        }
+      }
     }
   },
   "dynamicDefaults": {


### PR DESCRIPTION
Add read-only `stdout`, `stderr`, and `exitCode` properties to `src/schemas/src_schemas/runShell_v2.schema.json`.

* Add `stdout` property with type `string`, description "Standard output of the command.", and read-only.
* Add `stderr` property with type `string`, description "Standard error of the command.", and read-only.
* Add `exitCode` property with type `integer`, description "Exit code of the command.", and read-only.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/doc-detective/doc-detective-common/pull/71?shareId=e95e0c95-b4e3-41df-bea6-3d76c132ce45).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the command execution schema to include properties for capturing standard output, standard error, and exit code, improving tracking of command results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->