### PR TITLE
Updated click schema string shorthand to match the find schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-common",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-common",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-common",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Shared components for Doc Detective projects.",
   "main": "src/index.js",
   "scripts": {

--- a/src/schemas/output_schemas/click_v3.schema.json
+++ b/src/schemas/output_schemas/click_v3.schema.json
@@ -4,15 +4,12 @@
   "description": "Click or tap an element.",
   "anyOf": [
     {
-      "description": "Kind of click to perform.",
+      "title": "Find element (simple)",
       "type": "string",
-      "enum": [
-        "left",
-        "right",
-        "middle"
-      ]
+      "description": "Display text or selector of the element to find."
     },
     {
+      "title": "Click element (detailed)",
       "type": "object",
       "anyOf": [
         {
@@ -52,6 +49,11 @@
   ],
   "components": {
     "schemas": {
+      "string": {
+        "title": "Find element (simple)",
+        "type": "string",
+        "description": "Display text or selector of the element to find."
+      },
       "button": {
         "description": "Kind of click to perform.",
         "type": "string",
@@ -62,6 +64,7 @@
         ]
       },
       "object": {
+        "title": "Click element (detailed)",
         "type": "object",
         "anyOf": [
           {

--- a/src/schemas/output_schemas/config_v3.schema.json
+++ b/src/schemas/output_schemas/config_v3.schema.json
@@ -1047,15 +1047,12 @@
                                                 "description": "Click or tap an element.",
                                                 "anyOf": [
                                                   {
-                                                    "description": "Kind of click to perform.",
+                                                    "title": "Find element (simple)",
                                                     "type": "string",
-                                                    "enum": [
-                                                      "left",
-                                                      "right",
-                                                      "middle"
-                                                    ]
+                                                    "description": "Display text or selector of the element to find."
                                                   },
                                                   {
+                                                    "title": "Click element (detailed)",
                                                     "type": "object",
                                                     "anyOf": [
                                                       {
@@ -1095,6 +1092,11 @@
                                                 ],
                                                 "components": {
                                                   "schemas": {
+                                                    "string": {
+                                                      "title": "Find element (simple)",
+                                                      "type": "string",
+                                                      "description": "Display text or selector of the element to find."
+                                                    },
                                                     "button": {
                                                       "description": "Kind of click to perform.",
                                                       "type": "string",
@@ -1105,6 +1107,7 @@
                                                       ]
                                                     },
                                                     "object": {
+                                                      "title": "Click element (detailed)",
                                                       "type": "object",
                                                       "anyOf": [
                                                         {
@@ -1258,15 +1261,12 @@
                                                             "description": "Click or tap an element.",
                                                             "anyOf": [
                                                               {
-                                                                "description": "Kind of click to perform.",
+                                                                "title": "Find element (simple)",
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "left",
-                                                                  "right",
-                                                                  "middle"
-                                                                ]
+                                                                "description": "Display text or selector of the element to find."
                                                               },
                                                               {
+                                                                "title": "Click element (detailed)",
                                                                 "type": "object",
                                                                 "anyOf": [
                                                                   {
@@ -1306,6 +1306,11 @@
                                                             ],
                                                             "components": {
                                                               "schemas": {
+                                                                "string": {
+                                                                  "title": "Find element (simple)",
+                                                                  "type": "string",
+                                                                  "description": "Display text or selector of the element to find."
+                                                                },
                                                                 "button": {
                                                                   "description": "Kind of click to perform.",
                                                                   "type": "string",
@@ -1316,6 +1321,7 @@
                                                                   ]
                                                                 },
                                                                 "object": {
+                                                                  "title": "Click element (detailed)",
                                                                   "type": "object",
                                                                   "anyOf": [
                                                                     {
@@ -1593,15 +1599,12 @@
                                                               "description": "Click or tap an element.",
                                                               "anyOf": [
                                                                 {
-                                                                  "description": "Kind of click to perform.",
+                                                                  "title": "Find element (simple)",
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "left",
-                                                                    "right",
-                                                                    "middle"
-                                                                  ]
+                                                                  "description": "Display text or selector of the element to find."
                                                                 },
                                                                 {
+                                                                  "title": "Click element (detailed)",
                                                                   "type": "object",
                                                                   "anyOf": [
                                                                     {
@@ -1641,6 +1644,11 @@
                                                               ],
                                                               "components": {
                                                                 "schemas": {
+                                                                  "string": {
+                                                                    "title": "Find element (simple)",
+                                                                    "type": "string",
+                                                                    "description": "Display text or selector of the element to find."
+                                                                  },
                                                                   "button": {
                                                                     "description": "Kind of click to perform.",
                                                                     "type": "string",
@@ -1651,6 +1659,7 @@
                                                                     ]
                                                                   },
                                                                   "object": {
+                                                                    "title": "Click element (detailed)",
                                                                     "type": "object",
                                                                     "anyOf": [
                                                                       {
@@ -5687,15 +5696,12 @@
                                   "description": "Click or tap an element.",
                                   "anyOf": [
                                     {
-                                      "description": "Kind of click to perform.",
+                                      "title": "Find element (simple)",
                                       "type": "string",
-                                      "enum": [
-                                        "left",
-                                        "right",
-                                        "middle"
-                                      ]
+                                      "description": "Display text or selector of the element to find."
                                     },
                                     {
+                                      "title": "Click element (detailed)",
                                       "type": "object",
                                       "anyOf": [
                                         {
@@ -5735,6 +5741,11 @@
                                   ],
                                   "components": {
                                     "schemas": {
+                                      "string": {
+                                        "title": "Find element (simple)",
+                                        "type": "string",
+                                        "description": "Display text or selector of the element to find."
+                                      },
                                       "button": {
                                         "description": "Kind of click to perform.",
                                         "type": "string",
@@ -5745,6 +5756,7 @@
                                         ]
                                       },
                                       "object": {
+                                        "title": "Click element (detailed)",
                                         "type": "object",
                                         "anyOf": [
                                           {
@@ -5898,15 +5910,12 @@
                                               "description": "Click or tap an element.",
                                               "anyOf": [
                                                 {
-                                                  "description": "Kind of click to perform.",
+                                                  "title": "Find element (simple)",
                                                   "type": "string",
-                                                  "enum": [
-                                                    "left",
-                                                    "right",
-                                                    "middle"
-                                                  ]
+                                                  "description": "Display text or selector of the element to find."
                                                 },
                                                 {
+                                                  "title": "Click element (detailed)",
                                                   "type": "object",
                                                   "anyOf": [
                                                     {
@@ -5946,6 +5955,11 @@
                                               ],
                                               "components": {
                                                 "schemas": {
+                                                  "string": {
+                                                    "title": "Find element (simple)",
+                                                    "type": "string",
+                                                    "description": "Display text or selector of the element to find."
+                                                  },
                                                   "button": {
                                                     "description": "Kind of click to perform.",
                                                     "type": "string",
@@ -5956,6 +5970,7 @@
                                                     ]
                                                   },
                                                   "object": {
+                                                    "title": "Click element (detailed)",
                                                     "type": "object",
                                                     "anyOf": [
                                                       {
@@ -6233,15 +6248,12 @@
                                                 "description": "Click or tap an element.",
                                                 "anyOf": [
                                                   {
-                                                    "description": "Kind of click to perform.",
+                                                    "title": "Find element (simple)",
                                                     "type": "string",
-                                                    "enum": [
-                                                      "left",
-                                                      "right",
-                                                      "middle"
-                                                    ]
+                                                    "description": "Display text or selector of the element to find."
                                                   },
                                                   {
+                                                    "title": "Click element (detailed)",
                                                     "type": "object",
                                                     "anyOf": [
                                                       {
@@ -6281,6 +6293,11 @@
                                                 ],
                                                 "components": {
                                                   "schemas": {
+                                                    "string": {
+                                                      "title": "Find element (simple)",
+                                                      "type": "string",
+                                                      "description": "Display text or selector of the element to find."
+                                                    },
                                                     "button": {
                                                       "description": "Kind of click to perform.",
                                                       "type": "string",
@@ -6291,6 +6308,7 @@
                                                       ]
                                                     },
                                                     "object": {
+                                                      "title": "Click element (detailed)",
                                                       "type": "object",
                                                       "anyOf": [
                                                         {

--- a/src/schemas/output_schemas/find_v3.schema.json
+++ b/src/schemas/output_schemas/find_v3.schema.json
@@ -52,15 +52,12 @@
               "description": "Click or tap an element.",
               "anyOf": [
                 {
-                  "description": "Kind of click to perform.",
+                  "title": "Find element (simple)",
                   "type": "string",
-                  "enum": [
-                    "left",
-                    "right",
-                    "middle"
-                  ]
+                  "description": "Display text or selector of the element to find."
                 },
                 {
+                  "title": "Click element (detailed)",
                   "type": "object",
                   "anyOf": [
                     {
@@ -100,6 +97,11 @@
               ],
               "components": {
                 "schemas": {
+                  "string": {
+                    "title": "Find element (simple)",
+                    "type": "string",
+                    "description": "Display text or selector of the element to find."
+                  },
                   "button": {
                     "description": "Kind of click to perform.",
                     "type": "string",
@@ -110,6 +112,7 @@
                     ]
                   },
                   "object": {
+                    "title": "Click element (detailed)",
                     "type": "object",
                     "anyOf": [
                       {
@@ -387,15 +390,12 @@
                 "description": "Click or tap an element.",
                 "anyOf": [
                   {
-                    "description": "Kind of click to perform.",
+                    "title": "Find element (simple)",
                     "type": "string",
-                    "enum": [
-                      "left",
-                      "right",
-                      "middle"
-                    ]
+                    "description": "Display text or selector of the element to find."
                   },
                   {
+                    "title": "Click element (detailed)",
                     "type": "object",
                     "anyOf": [
                       {
@@ -435,6 +435,11 @@
                 ],
                 "components": {
                   "schemas": {
+                    "string": {
+                      "title": "Find element (simple)",
+                      "type": "string",
+                      "description": "Display text or selector of the element to find."
+                    },
                     "button": {
                       "description": "Kind of click to perform.",
                       "type": "string",
@@ -445,6 +450,7 @@
                       ]
                     },
                     "object": {
+                      "title": "Click element (detailed)",
                       "type": "object",
                       "anyOf": [
                         {

--- a/src/schemas/output_schemas/report_v3.schema.json
+++ b/src/schemas/output_schemas/report_v3.schema.json
@@ -1476,15 +1476,12 @@
                                         "description": "Click or tap an element.",
                                         "anyOf": [
                                           {
-                                            "description": "Kind of click to perform.",
+                                            "title": "Find element (simple)",
                                             "type": "string",
-                                            "enum": [
-                                              "left",
-                                              "right",
-                                              "middle"
-                                            ]
+                                            "description": "Display text or selector of the element to find."
                                           },
                                           {
+                                            "title": "Click element (detailed)",
                                             "type": "object",
                                             "anyOf": [
                                               {
@@ -1524,6 +1521,11 @@
                                         ],
                                         "components": {
                                           "schemas": {
+                                            "string": {
+                                              "title": "Find element (simple)",
+                                              "type": "string",
+                                              "description": "Display text or selector of the element to find."
+                                            },
                                             "button": {
                                               "description": "Kind of click to perform.",
                                               "type": "string",
@@ -1534,6 +1536,7 @@
                                               ]
                                             },
                                             "object": {
+                                              "title": "Click element (detailed)",
                                               "type": "object",
                                               "anyOf": [
                                                 {
@@ -1687,15 +1690,12 @@
                                                     "description": "Click or tap an element.",
                                                     "anyOf": [
                                                       {
-                                                        "description": "Kind of click to perform.",
+                                                        "title": "Find element (simple)",
                                                         "type": "string",
-                                                        "enum": [
-                                                          "left",
-                                                          "right",
-                                                          "middle"
-                                                        ]
+                                                        "description": "Display text or selector of the element to find."
                                                       },
                                                       {
+                                                        "title": "Click element (detailed)",
                                                         "type": "object",
                                                         "anyOf": [
                                                           {
@@ -1735,6 +1735,11 @@
                                                     ],
                                                     "components": {
                                                       "schemas": {
+                                                        "string": {
+                                                          "title": "Find element (simple)",
+                                                          "type": "string",
+                                                          "description": "Display text or selector of the element to find."
+                                                        },
                                                         "button": {
                                                           "description": "Kind of click to perform.",
                                                           "type": "string",
@@ -1745,6 +1750,7 @@
                                                           ]
                                                         },
                                                         "object": {
+                                                          "title": "Click element (detailed)",
                                                           "type": "object",
                                                           "anyOf": [
                                                             {
@@ -2022,15 +2028,12 @@
                                                       "description": "Click or tap an element.",
                                                       "anyOf": [
                                                         {
-                                                          "description": "Kind of click to perform.",
+                                                          "title": "Find element (simple)",
                                                           "type": "string",
-                                                          "enum": [
-                                                            "left",
-                                                            "right",
-                                                            "middle"
-                                                          ]
+                                                          "description": "Display text or selector of the element to find."
                                                         },
                                                         {
+                                                          "title": "Click element (detailed)",
                                                           "type": "object",
                                                           "anyOf": [
                                                             {
@@ -2070,6 +2073,11 @@
                                                       ],
                                                       "components": {
                                                         "schemas": {
+                                                          "string": {
+                                                            "title": "Find element (simple)",
+                                                            "type": "string",
+                                                            "description": "Display text or selector of the element to find."
+                                                          },
                                                           "button": {
                                                             "description": "Kind of click to perform.",
                                                             "type": "string",
@@ -2080,6 +2088,7 @@
                                                             ]
                                                           },
                                                           "object": {
+                                                            "title": "Click element (detailed)",
                                                             "type": "object",
                                                             "anyOf": [
                                                               {

--- a/src/schemas/output_schemas/spec_v3.schema.json
+++ b/src/schemas/output_schemas/spec_v3.schema.json
@@ -1458,15 +1458,12 @@
                               "description": "Click or tap an element.",
                               "anyOf": [
                                 {
-                                  "description": "Kind of click to perform.",
+                                  "title": "Find element (simple)",
                                   "type": "string",
-                                  "enum": [
-                                    "left",
-                                    "right",
-                                    "middle"
-                                  ]
+                                  "description": "Display text or selector of the element to find."
                                 },
                                 {
+                                  "title": "Click element (detailed)",
                                   "type": "object",
                                   "anyOf": [
                                     {
@@ -1506,6 +1503,11 @@
                               ],
                               "components": {
                                 "schemas": {
+                                  "string": {
+                                    "title": "Find element (simple)",
+                                    "type": "string",
+                                    "description": "Display text or selector of the element to find."
+                                  },
                                   "button": {
                                     "description": "Kind of click to perform.",
                                     "type": "string",
@@ -1516,6 +1518,7 @@
                                     ]
                                   },
                                   "object": {
+                                    "title": "Click element (detailed)",
                                     "type": "object",
                                     "anyOf": [
                                       {
@@ -1669,15 +1672,12 @@
                                           "description": "Click or tap an element.",
                                           "anyOf": [
                                             {
-                                              "description": "Kind of click to perform.",
+                                              "title": "Find element (simple)",
                                               "type": "string",
-                                              "enum": [
-                                                "left",
-                                                "right",
-                                                "middle"
-                                              ]
+                                              "description": "Display text or selector of the element to find."
                                             },
                                             {
+                                              "title": "Click element (detailed)",
                                               "type": "object",
                                               "anyOf": [
                                                 {
@@ -1717,6 +1717,11 @@
                                           ],
                                           "components": {
                                             "schemas": {
+                                              "string": {
+                                                "title": "Find element (simple)",
+                                                "type": "string",
+                                                "description": "Display text or selector of the element to find."
+                                              },
                                               "button": {
                                                 "description": "Kind of click to perform.",
                                                 "type": "string",
@@ -1727,6 +1732,7 @@
                                                 ]
                                               },
                                               "object": {
+                                                "title": "Click element (detailed)",
                                                 "type": "object",
                                                 "anyOf": [
                                                   {
@@ -2004,15 +2010,12 @@
                                             "description": "Click or tap an element.",
                                             "anyOf": [
                                               {
-                                                "description": "Kind of click to perform.",
+                                                "title": "Find element (simple)",
                                                 "type": "string",
-                                                "enum": [
-                                                  "left",
-                                                  "right",
-                                                  "middle"
-                                                ]
+                                                "description": "Display text or selector of the element to find."
                                               },
                                               {
+                                                "title": "Click element (detailed)",
                                                 "type": "object",
                                                 "anyOf": [
                                                   {
@@ -2052,6 +2055,11 @@
                                             ],
                                             "components": {
                                               "schemas": {
+                                                "string": {
+                                                  "title": "Find element (simple)",
+                                                  "type": "string",
+                                                  "description": "Display text or selector of the element to find."
+                                                },
                                                 "button": {
                                                   "description": "Kind of click to perform.",
                                                   "type": "string",
@@ -2062,6 +2070,7 @@
                                                   ]
                                                 },
                                                 "object": {
+                                                  "title": "Click element (detailed)",
                                                   "type": "object",
                                                   "anyOf": [
                                                     {

--- a/src/schemas/output_schemas/step_v3.schema.json
+++ b/src/schemas/output_schemas/step_v3.schema.json
@@ -319,15 +319,12 @@
               "description": "Click or tap an element.",
               "anyOf": [
                 {
-                  "description": "Kind of click to perform.",
+                  "title": "Find element (simple)",
                   "type": "string",
-                  "enum": [
-                    "left",
-                    "right",
-                    "middle"
-                  ]
+                  "description": "Display text or selector of the element to find."
                 },
                 {
+                  "title": "Click element (detailed)",
                   "type": "object",
                   "anyOf": [
                     {
@@ -367,6 +364,11 @@
               ],
               "components": {
                 "schemas": {
+                  "string": {
+                    "title": "Find element (simple)",
+                    "type": "string",
+                    "description": "Display text or selector of the element to find."
+                  },
                   "button": {
                     "description": "Kind of click to perform.",
                     "type": "string",
@@ -377,6 +379,7 @@
                     ]
                   },
                   "object": {
+                    "title": "Click element (detailed)",
                     "type": "object",
                     "anyOf": [
                       {
@@ -530,15 +533,12 @@
                           "description": "Click or tap an element.",
                           "anyOf": [
                             {
-                              "description": "Kind of click to perform.",
+                              "title": "Find element (simple)",
                               "type": "string",
-                              "enum": [
-                                "left",
-                                "right",
-                                "middle"
-                              ]
+                              "description": "Display text or selector of the element to find."
                             },
                             {
+                              "title": "Click element (detailed)",
                               "type": "object",
                               "anyOf": [
                                 {
@@ -578,6 +578,11 @@
                           ],
                           "components": {
                             "schemas": {
+                              "string": {
+                                "title": "Find element (simple)",
+                                "type": "string",
+                                "description": "Display text or selector of the element to find."
+                              },
                               "button": {
                                 "description": "Kind of click to perform.",
                                 "type": "string",
@@ -588,6 +593,7 @@
                                 ]
                               },
                               "object": {
+                                "title": "Click element (detailed)",
                                 "type": "object",
                                 "anyOf": [
                                   {
@@ -865,15 +871,12 @@
                             "description": "Click or tap an element.",
                             "anyOf": [
                               {
-                                "description": "Kind of click to perform.",
+                                "title": "Find element (simple)",
                                 "type": "string",
-                                "enum": [
-                                  "left",
-                                  "right",
-                                  "middle"
-                                ]
+                                "description": "Display text or selector of the element to find."
                               },
                               {
+                                "title": "Click element (detailed)",
                                 "type": "object",
                                 "anyOf": [
                                   {
@@ -913,6 +916,11 @@
                             ],
                             "components": {
                               "schemas": {
+                                "string": {
+                                  "title": "Find element (simple)",
+                                  "type": "string",
+                                  "description": "Display text or selector of the element to find."
+                                },
                                 "button": {
                                   "description": "Kind of click to perform.",
                                   "type": "string",
@@ -923,6 +931,7 @@
                                   ]
                                 },
                                 "object": {
+                                  "title": "Click element (detailed)",
                                   "type": "object",
                                   "anyOf": [
                                     {

--- a/src/schemas/output_schemas/test_v3.schema.json
+++ b/src/schemas/output_schemas/test_v3.schema.json
@@ -893,15 +893,12 @@
                     "description": "Click or tap an element.",
                     "anyOf": [
                       {
-                        "description": "Kind of click to perform.",
+                        "title": "Find element (simple)",
                         "type": "string",
-                        "enum": [
-                          "left",
-                          "right",
-                          "middle"
-                        ]
+                        "description": "Display text or selector of the element to find."
                       },
                       {
+                        "title": "Click element (detailed)",
                         "type": "object",
                         "anyOf": [
                           {
@@ -941,6 +938,11 @@
                     ],
                     "components": {
                       "schemas": {
+                        "string": {
+                          "title": "Find element (simple)",
+                          "type": "string",
+                          "description": "Display text or selector of the element to find."
+                        },
                         "button": {
                           "description": "Kind of click to perform.",
                           "type": "string",
@@ -951,6 +953,7 @@
                           ]
                         },
                         "object": {
+                          "title": "Click element (detailed)",
                           "type": "object",
                           "anyOf": [
                             {
@@ -1104,15 +1107,12 @@
                                 "description": "Click or tap an element.",
                                 "anyOf": [
                                   {
-                                    "description": "Kind of click to perform.",
+                                    "title": "Find element (simple)",
                                     "type": "string",
-                                    "enum": [
-                                      "left",
-                                      "right",
-                                      "middle"
-                                    ]
+                                    "description": "Display text or selector of the element to find."
                                   },
                                   {
+                                    "title": "Click element (detailed)",
                                     "type": "object",
                                     "anyOf": [
                                       {
@@ -1152,6 +1152,11 @@
                                 ],
                                 "components": {
                                   "schemas": {
+                                    "string": {
+                                      "title": "Find element (simple)",
+                                      "type": "string",
+                                      "description": "Display text or selector of the element to find."
+                                    },
                                     "button": {
                                       "description": "Kind of click to perform.",
                                       "type": "string",
@@ -1162,6 +1167,7 @@
                                       ]
                                     },
                                     "object": {
+                                      "title": "Click element (detailed)",
                                       "type": "object",
                                       "anyOf": [
                                         {
@@ -1439,15 +1445,12 @@
                                   "description": "Click or tap an element.",
                                   "anyOf": [
                                     {
-                                      "description": "Kind of click to perform.",
+                                      "title": "Find element (simple)",
                                       "type": "string",
-                                      "enum": [
-                                        "left",
-                                        "right",
-                                        "middle"
-                                      ]
+                                      "description": "Display text or selector of the element to find."
                                     },
                                     {
+                                      "title": "Click element (detailed)",
                                       "type": "object",
                                       "anyOf": [
                                         {
@@ -1487,6 +1490,11 @@
                                   ],
                                   "components": {
                                     "schemas": {
+                                      "string": {
+                                        "title": "Find element (simple)",
+                                        "type": "string",
+                                        "description": "Display text or selector of the element to find."
+                                      },
                                       "button": {
                                         "description": "Kind of click to perform.",
                                         "type": "string",
@@ -1497,6 +1505,7 @@
                                         ]
                                       },
                                       "object": {
+                                        "title": "Click element (detailed)",
                                         "type": "object",
                                         "anyOf": [
                                           {

--- a/src/schemas/schemas.json
+++ b/src/schemas/schemas.json
@@ -146,15 +146,12 @@
     "description": "Click or tap an element.",
     "anyOf": [
       {
-        "description": "Kind of click to perform.",
+        "title": "Find element (simple)",
         "type": "string",
-        "enum": [
-          "left",
-          "right",
-          "middle"
-        ]
+        "description": "Display text or selector of the element to find."
       },
       {
+        "title": "Click element (detailed)",
         "type": "object",
         "anyOf": [
           {
@@ -194,6 +191,11 @@
     ],
     "components": {
       "schemas": {
+        "string": {
+          "title": "Find element (simple)",
+          "type": "string",
+          "description": "Display text or selector of the element to find."
+        },
         "button": {
           "description": "Kind of click to perform.",
           "type": "string",
@@ -204,6 +206,7 @@
           ]
         },
         "object": {
+          "title": "Click element (detailed)",
           "type": "object",
           "anyOf": [
             {
@@ -1302,15 +1305,12 @@
                                                   "description": "Click or tap an element.",
                                                   "anyOf": [
                                                     {
-                                                      "description": "Kind of click to perform.",
+                                                      "title": "Find element (simple)",
                                                       "type": "string",
-                                                      "enum": [
-                                                        "left",
-                                                        "right",
-                                                        "middle"
-                                                      ]
+                                                      "description": "Display text or selector of the element to find."
                                                     },
                                                     {
+                                                      "title": "Click element (detailed)",
                                                       "type": "object",
                                                       "anyOf": [
                                                         {
@@ -1350,6 +1350,11 @@
                                                   ],
                                                   "components": {
                                                     "schemas": {
+                                                      "string": {
+                                                        "title": "Find element (simple)",
+                                                        "type": "string",
+                                                        "description": "Display text or selector of the element to find."
+                                                      },
                                                       "button": {
                                                         "description": "Kind of click to perform.",
                                                         "type": "string",
@@ -1360,6 +1365,7 @@
                                                         ]
                                                       },
                                                       "object": {
+                                                        "title": "Click element (detailed)",
                                                         "type": "object",
                                                         "anyOf": [
                                                           {
@@ -1513,15 +1519,12 @@
                                                               "description": "Click or tap an element.",
                                                               "anyOf": [
                                                                 {
-                                                                  "description": "Kind of click to perform.",
+                                                                  "title": "Find element (simple)",
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "left",
-                                                                    "right",
-                                                                    "middle"
-                                                                  ]
+                                                                  "description": "Display text or selector of the element to find."
                                                                 },
                                                                 {
+                                                                  "title": "Click element (detailed)",
                                                                   "type": "object",
                                                                   "anyOf": [
                                                                     {
@@ -1561,6 +1564,11 @@
                                                               ],
                                                               "components": {
                                                                 "schemas": {
+                                                                  "string": {
+                                                                    "title": "Find element (simple)",
+                                                                    "type": "string",
+                                                                    "description": "Display text or selector of the element to find."
+                                                                  },
                                                                   "button": {
                                                                     "description": "Kind of click to perform.",
                                                                     "type": "string",
@@ -1571,6 +1579,7 @@
                                                                     ]
                                                                   },
                                                                   "object": {
+                                                                    "title": "Click element (detailed)",
                                                                     "type": "object",
                                                                     "anyOf": [
                                                                       {
@@ -1848,15 +1857,12 @@
                                                                 "description": "Click or tap an element.",
                                                                 "anyOf": [
                                                                   {
-                                                                    "description": "Kind of click to perform.",
+                                                                    "title": "Find element (simple)",
                                                                     "type": "string",
-                                                                    "enum": [
-                                                                      "left",
-                                                                      "right",
-                                                                      "middle"
-                                                                    ]
+                                                                    "description": "Display text or selector of the element to find."
                                                                   },
                                                                   {
+                                                                    "title": "Click element (detailed)",
                                                                     "type": "object",
                                                                     "anyOf": [
                                                                       {
@@ -1896,6 +1902,11 @@
                                                                 ],
                                                                 "components": {
                                                                   "schemas": {
+                                                                    "string": {
+                                                                      "title": "Find element (simple)",
+                                                                      "type": "string",
+                                                                      "description": "Display text or selector of the element to find."
+                                                                    },
                                                                     "button": {
                                                                       "description": "Kind of click to perform.",
                                                                       "type": "string",
@@ -1906,6 +1917,7 @@
                                                                       ]
                                                                     },
                                                                     "object": {
+                                                                      "title": "Click element (detailed)",
                                                                       "type": "object",
                                                                       "anyOf": [
                                                                         {
@@ -5942,15 +5954,12 @@
                                     "description": "Click or tap an element.",
                                     "anyOf": [
                                       {
-                                        "description": "Kind of click to perform.",
+                                        "title": "Find element (simple)",
                                         "type": "string",
-                                        "enum": [
-                                          "left",
-                                          "right",
-                                          "middle"
-                                        ]
+                                        "description": "Display text or selector of the element to find."
                                       },
                                       {
+                                        "title": "Click element (detailed)",
                                         "type": "object",
                                         "anyOf": [
                                           {
@@ -5990,6 +5999,11 @@
                                     ],
                                     "components": {
                                       "schemas": {
+                                        "string": {
+                                          "title": "Find element (simple)",
+                                          "type": "string",
+                                          "description": "Display text or selector of the element to find."
+                                        },
                                         "button": {
                                           "description": "Kind of click to perform.",
                                           "type": "string",
@@ -6000,6 +6014,7 @@
                                           ]
                                         },
                                         "object": {
+                                          "title": "Click element (detailed)",
                                           "type": "object",
                                           "anyOf": [
                                             {
@@ -6153,15 +6168,12 @@
                                                 "description": "Click or tap an element.",
                                                 "anyOf": [
                                                   {
-                                                    "description": "Kind of click to perform.",
+                                                    "title": "Find element (simple)",
                                                     "type": "string",
-                                                    "enum": [
-                                                      "left",
-                                                      "right",
-                                                      "middle"
-                                                    ]
+                                                    "description": "Display text or selector of the element to find."
                                                   },
                                                   {
+                                                    "title": "Click element (detailed)",
                                                     "type": "object",
                                                     "anyOf": [
                                                       {
@@ -6201,6 +6213,11 @@
                                                 ],
                                                 "components": {
                                                   "schemas": {
+                                                    "string": {
+                                                      "title": "Find element (simple)",
+                                                      "type": "string",
+                                                      "description": "Display text or selector of the element to find."
+                                                    },
                                                     "button": {
                                                       "description": "Kind of click to perform.",
                                                       "type": "string",
@@ -6211,6 +6228,7 @@
                                                       ]
                                                     },
                                                     "object": {
+                                                      "title": "Click element (detailed)",
                                                       "type": "object",
                                                       "anyOf": [
                                                         {
@@ -6488,15 +6506,12 @@
                                                   "description": "Click or tap an element.",
                                                   "anyOf": [
                                                     {
-                                                      "description": "Kind of click to perform.",
+                                                      "title": "Find element (simple)",
                                                       "type": "string",
-                                                      "enum": [
-                                                        "left",
-                                                        "right",
-                                                        "middle"
-                                                      ]
+                                                      "description": "Display text or selector of the element to find."
                                                     },
                                                     {
+                                                      "title": "Click element (detailed)",
                                                       "type": "object",
                                                       "anyOf": [
                                                         {
@@ -6536,6 +6551,11 @@
                                                   ],
                                                   "components": {
                                                     "schemas": {
+                                                      "string": {
+                                                        "title": "Find element (simple)",
+                                                        "type": "string",
+                                                        "description": "Display text or selector of the element to find."
+                                                      },
                                                       "button": {
                                                         "description": "Kind of click to perform.",
                                                         "type": "string",
@@ -6546,6 +6566,7 @@
                                                         ]
                                                       },
                                                       "object": {
+                                                        "title": "Click element (detailed)",
                                                         "type": "object",
                                                         "anyOf": [
                                                           {
@@ -10329,15 +10350,12 @@
                 "description": "Click or tap an element.",
                 "anyOf": [
                   {
-                    "description": "Kind of click to perform.",
+                    "title": "Find element (simple)",
                     "type": "string",
-                    "enum": [
-                      "left",
-                      "right",
-                      "middle"
-                    ]
+                    "description": "Display text or selector of the element to find."
                   },
                   {
+                    "title": "Click element (detailed)",
                     "type": "object",
                     "anyOf": [
                       {
@@ -10377,6 +10395,11 @@
                 ],
                 "components": {
                   "schemas": {
+                    "string": {
+                      "title": "Find element (simple)",
+                      "type": "string",
+                      "description": "Display text or selector of the element to find."
+                    },
                     "button": {
                       "description": "Kind of click to perform.",
                       "type": "string",
@@ -10387,6 +10410,7 @@
                       ]
                     },
                     "object": {
+                      "title": "Click element (detailed)",
                       "type": "object",
                       "anyOf": [
                         {
@@ -10664,15 +10688,12 @@
                   "description": "Click or tap an element.",
                   "anyOf": [
                     {
-                      "description": "Kind of click to perform.",
+                      "title": "Find element (simple)",
                       "type": "string",
-                      "enum": [
-                        "left",
-                        "right",
-                        "middle"
-                      ]
+                      "description": "Display text or selector of the element to find."
                     },
                     {
+                      "title": "Click element (detailed)",
                       "type": "object",
                       "anyOf": [
                         {
@@ -10712,6 +10733,11 @@
                   ],
                   "components": {
                     "schemas": {
+                      "string": {
+                        "title": "Find element (simple)",
+                        "type": "string",
+                        "description": "Display text or selector of the element to find."
+                      },
                       "button": {
                         "description": "Kind of click to perform.",
                         "type": "string",
@@ -10722,6 +10748,7 @@
                         ]
                       },
                       "object": {
+                        "title": "Click element (detailed)",
                         "type": "object",
                         "anyOf": [
                           {
@@ -13657,15 +13684,12 @@
                                           "description": "Click or tap an element.",
                                           "anyOf": [
                                             {
-                                              "description": "Kind of click to perform.",
+                                              "title": "Find element (simple)",
                                               "type": "string",
-                                              "enum": [
-                                                "left",
-                                                "right",
-                                                "middle"
-                                              ]
+                                              "description": "Display text or selector of the element to find."
                                             },
                                             {
+                                              "title": "Click element (detailed)",
                                               "type": "object",
                                               "anyOf": [
                                                 {
@@ -13705,6 +13729,11 @@
                                           ],
                                           "components": {
                                             "schemas": {
+                                              "string": {
+                                                "title": "Find element (simple)",
+                                                "type": "string",
+                                                "description": "Display text or selector of the element to find."
+                                              },
                                               "button": {
                                                 "description": "Kind of click to perform.",
                                                 "type": "string",
@@ -13715,6 +13744,7 @@
                                                 ]
                                               },
                                               "object": {
+                                                "title": "Click element (detailed)",
                                                 "type": "object",
                                                 "anyOf": [
                                                   {
@@ -13868,15 +13898,12 @@
                                                       "description": "Click or tap an element.",
                                                       "anyOf": [
                                                         {
-                                                          "description": "Kind of click to perform.",
+                                                          "title": "Find element (simple)",
                                                           "type": "string",
-                                                          "enum": [
-                                                            "left",
-                                                            "right",
-                                                            "middle"
-                                                          ]
+                                                          "description": "Display text or selector of the element to find."
                                                         },
                                                         {
+                                                          "title": "Click element (detailed)",
                                                           "type": "object",
                                                           "anyOf": [
                                                             {
@@ -13916,6 +13943,11 @@
                                                       ],
                                                       "components": {
                                                         "schemas": {
+                                                          "string": {
+                                                            "title": "Find element (simple)",
+                                                            "type": "string",
+                                                            "description": "Display text or selector of the element to find."
+                                                          },
                                                           "button": {
                                                             "description": "Kind of click to perform.",
                                                             "type": "string",
@@ -13926,6 +13958,7 @@
                                                             ]
                                                           },
                                                           "object": {
+                                                            "title": "Click element (detailed)",
                                                             "type": "object",
                                                             "anyOf": [
                                                               {
@@ -14203,15 +14236,12 @@
                                                         "description": "Click or tap an element.",
                                                         "anyOf": [
                                                           {
-                                                            "description": "Kind of click to perform.",
+                                                            "title": "Find element (simple)",
                                                             "type": "string",
-                                                            "enum": [
-                                                              "left",
-                                                              "right",
-                                                              "middle"
-                                                            ]
+                                                            "description": "Display text or selector of the element to find."
                                                           },
                                                           {
+                                                            "title": "Click element (detailed)",
                                                             "type": "object",
                                                             "anyOf": [
                                                               {
@@ -14251,6 +14281,11 @@
                                                         ],
                                                         "components": {
                                                           "schemas": {
+                                                            "string": {
+                                                              "title": "Find element (simple)",
+                                                              "type": "string",
+                                                              "description": "Display text or selector of the element to find."
+                                                            },
                                                             "button": {
                                                               "description": "Kind of click to perform.",
                                                               "type": "string",
@@ -14261,6 +14296,7 @@
                                                               ]
                                                             },
                                                             "object": {
+                                                              "title": "Click element (detailed)",
                                                               "type": "object",
                                                               "anyOf": [
                                                                 {
@@ -20203,15 +20239,12 @@
                                 "description": "Click or tap an element.",
                                 "anyOf": [
                                   {
-                                    "description": "Kind of click to perform.",
+                                    "title": "Find element (simple)",
                                     "type": "string",
-                                    "enum": [
-                                      "left",
-                                      "right",
-                                      "middle"
-                                    ]
+                                    "description": "Display text or selector of the element to find."
                                   },
                                   {
+                                    "title": "Click element (detailed)",
                                     "type": "object",
                                     "anyOf": [
                                       {
@@ -20251,6 +20284,11 @@
                                 ],
                                 "components": {
                                   "schemas": {
+                                    "string": {
+                                      "title": "Find element (simple)",
+                                      "type": "string",
+                                      "description": "Display text or selector of the element to find."
+                                    },
                                     "button": {
                                       "description": "Kind of click to perform.",
                                       "type": "string",
@@ -20261,6 +20299,7 @@
                                       ]
                                     },
                                     "object": {
+                                      "title": "Click element (detailed)",
                                       "type": "object",
                                       "anyOf": [
                                         {
@@ -20414,15 +20453,12 @@
                                             "description": "Click or tap an element.",
                                             "anyOf": [
                                               {
-                                                "description": "Kind of click to perform.",
+                                                "title": "Find element (simple)",
                                                 "type": "string",
-                                                "enum": [
-                                                  "left",
-                                                  "right",
-                                                  "middle"
-                                                ]
+                                                "description": "Display text or selector of the element to find."
                                               },
                                               {
+                                                "title": "Click element (detailed)",
                                                 "type": "object",
                                                 "anyOf": [
                                                   {
@@ -20462,6 +20498,11 @@
                                             ],
                                             "components": {
                                               "schemas": {
+                                                "string": {
+                                                  "title": "Find element (simple)",
+                                                  "type": "string",
+                                                  "description": "Display text or selector of the element to find."
+                                                },
                                                 "button": {
                                                   "description": "Kind of click to perform.",
                                                   "type": "string",
@@ -20472,6 +20513,7 @@
                                                   ]
                                                 },
                                                 "object": {
+                                                  "title": "Click element (detailed)",
                                                   "type": "object",
                                                   "anyOf": [
                                                     {
@@ -20749,15 +20791,12 @@
                                               "description": "Click or tap an element.",
                                               "anyOf": [
                                                 {
-                                                  "description": "Kind of click to perform.",
+                                                  "title": "Find element (simple)",
                                                   "type": "string",
-                                                  "enum": [
-                                                    "left",
-                                                    "right",
-                                                    "middle"
-                                                  ]
+                                                  "description": "Display text or selector of the element to find."
                                                 },
                                                 {
+                                                  "title": "Click element (detailed)",
                                                   "type": "object",
                                                   "anyOf": [
                                                     {
@@ -20797,6 +20836,11 @@
                                               ],
                                               "components": {
                                                 "schemas": {
+                                                  "string": {
+                                                    "title": "Find element (simple)",
+                                                    "type": "string",
+                                                    "description": "Display text or selector of the element to find."
+                                                  },
                                                   "button": {
                                                     "description": "Kind of click to perform.",
                                                     "type": "string",
@@ -20807,6 +20851,7 @@
                                                     ]
                                                   },
                                                   "object": {
+                                                    "title": "Click element (detailed)",
                                                     "type": "object",
                                                     "anyOf": [
                                                       {
@@ -24624,15 +24669,12 @@
                 "description": "Click or tap an element.",
                 "anyOf": [
                   {
-                    "description": "Kind of click to perform.",
+                    "title": "Find element (simple)",
                     "type": "string",
-                    "enum": [
-                      "left",
-                      "right",
-                      "middle"
-                    ]
+                    "description": "Display text or selector of the element to find."
                   },
                   {
+                    "title": "Click element (detailed)",
                     "type": "object",
                     "anyOf": [
                       {
@@ -24672,6 +24714,11 @@
                 ],
                 "components": {
                   "schemas": {
+                    "string": {
+                      "title": "Find element (simple)",
+                      "type": "string",
+                      "description": "Display text or selector of the element to find."
+                    },
                     "button": {
                       "description": "Kind of click to perform.",
                       "type": "string",
@@ -24682,6 +24729,7 @@
                       ]
                     },
                     "object": {
+                      "title": "Click element (detailed)",
                       "type": "object",
                       "anyOf": [
                         {
@@ -24835,15 +24883,12 @@
                             "description": "Click or tap an element.",
                             "anyOf": [
                               {
-                                "description": "Kind of click to perform.",
+                                "title": "Find element (simple)",
                                 "type": "string",
-                                "enum": [
-                                  "left",
-                                  "right",
-                                  "middle"
-                                ]
+                                "description": "Display text or selector of the element to find."
                               },
                               {
+                                "title": "Click element (detailed)",
                                 "type": "object",
                                 "anyOf": [
                                   {
@@ -24883,6 +24928,11 @@
                             ],
                             "components": {
                               "schemas": {
+                                "string": {
+                                  "title": "Find element (simple)",
+                                  "type": "string",
+                                  "description": "Display text or selector of the element to find."
+                                },
                                 "button": {
                                   "description": "Kind of click to perform.",
                                   "type": "string",
@@ -24893,6 +24943,7 @@
                                   ]
                                 },
                                 "object": {
+                                  "title": "Click element (detailed)",
                                   "type": "object",
                                   "anyOf": [
                                     {
@@ -25170,15 +25221,12 @@
                               "description": "Click or tap an element.",
                               "anyOf": [
                                 {
-                                  "description": "Kind of click to perform.",
+                                  "title": "Find element (simple)",
                                   "type": "string",
-                                  "enum": [
-                                    "left",
-                                    "right",
-                                    "middle"
-                                  ]
+                                  "description": "Display text or selector of the element to find."
                                 },
                                 {
+                                  "title": "Click element (detailed)",
                                   "type": "object",
                                   "anyOf": [
                                     {
@@ -25218,6 +25266,11 @@
                               ],
                               "components": {
                                 "schemas": {
+                                  "string": {
+                                    "title": "Find element (simple)",
+                                    "type": "string",
+                                    "description": "Display text or selector of the element to find."
+                                  },
                                   "button": {
                                     "description": "Kind of click to perform.",
                                     "type": "string",
@@ -25228,6 +25281,7 @@
                                     ]
                                   },
                                   "object": {
+                                    "title": "Click element (detailed)",
                                     "type": "object",
                                     "anyOf": [
                                       {
@@ -29294,15 +29348,12 @@
                       "description": "Click or tap an element.",
                       "anyOf": [
                         {
-                          "description": "Kind of click to perform.",
+                          "title": "Find element (simple)",
                           "type": "string",
-                          "enum": [
-                            "left",
-                            "right",
-                            "middle"
-                          ]
+                          "description": "Display text or selector of the element to find."
                         },
                         {
+                          "title": "Click element (detailed)",
                           "type": "object",
                           "anyOf": [
                             {
@@ -29342,6 +29393,11 @@
                       ],
                       "components": {
                         "schemas": {
+                          "string": {
+                            "title": "Find element (simple)",
+                            "type": "string",
+                            "description": "Display text or selector of the element to find."
+                          },
                           "button": {
                             "description": "Kind of click to perform.",
                             "type": "string",
@@ -29352,6 +29408,7 @@
                             ]
                           },
                           "object": {
+                            "title": "Click element (detailed)",
                             "type": "object",
                             "anyOf": [
                               {
@@ -29505,15 +29562,12 @@
                                   "description": "Click or tap an element.",
                                   "anyOf": [
                                     {
-                                      "description": "Kind of click to perform.",
+                                      "title": "Find element (simple)",
                                       "type": "string",
-                                      "enum": [
-                                        "left",
-                                        "right",
-                                        "middle"
-                                      ]
+                                      "description": "Display text or selector of the element to find."
                                     },
                                     {
+                                      "title": "Click element (detailed)",
                                       "type": "object",
                                       "anyOf": [
                                         {
@@ -29553,6 +29607,11 @@
                                   ],
                                   "components": {
                                     "schemas": {
+                                      "string": {
+                                        "title": "Find element (simple)",
+                                        "type": "string",
+                                        "description": "Display text or selector of the element to find."
+                                      },
                                       "button": {
                                         "description": "Kind of click to perform.",
                                         "type": "string",
@@ -29563,6 +29622,7 @@
                                         ]
                                       },
                                       "object": {
+                                        "title": "Click element (detailed)",
                                         "type": "object",
                                         "anyOf": [
                                           {
@@ -29840,15 +29900,12 @@
                                     "description": "Click or tap an element.",
                                     "anyOf": [
                                       {
-                                        "description": "Kind of click to perform.",
+                                        "title": "Find element (simple)",
                                         "type": "string",
-                                        "enum": [
-                                          "left",
-                                          "right",
-                                          "middle"
-                                        ]
+                                        "description": "Display text or selector of the element to find."
                                       },
                                       {
+                                        "title": "Click element (detailed)",
                                         "type": "object",
                                         "anyOf": [
                                           {
@@ -29888,6 +29945,11 @@
                                     ],
                                     "components": {
                                       "schemas": {
+                                        "string": {
+                                          "title": "Find element (simple)",
+                                          "type": "string",
+                                          "description": "Display text or selector of the element to find."
+                                        },
                                         "button": {
                                           "description": "Kind of click to perform.",
                                           "type": "string",
@@ -29898,6 +29960,7 @@
                                           ]
                                         },
                                         "object": {
+                                          "title": "Click element (detailed)",
                                           "type": "object",
                                           "anyOf": [
                                             {

--- a/src/schemas/src_schemas/click_v3.schema.json
+++ b/src/schemas/src_schemas/click_v3.schema.json
@@ -4,7 +4,7 @@
   "description": "Click or tap an element.",
   "anyOf": [
     {
-      "$ref": "#/components/schemas/button"
+      "$ref": "#/components/schemas/string"
     },
     {
       "$ref": "#/components/schemas/object"
@@ -15,12 +15,18 @@
   ],
   "components": {
     "schemas": {
+      "string": {
+        "title": "Find element (simple)",
+        "type": "string",
+        "description": "Display text or selector of the element to find."
+      },
       "button": {
         "description": "Kind of click to perform.",
         "type": "string",
         "enum": ["left", "right", "middle"]
       },
       "object": {
+        "title": "Click element (detailed)",
         "type": "object",
         "anyOf": [
           {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated schema descriptions and titles for "click" and "find" actions to clarify that simple string values represent the display text or selector of the element to find, rather than click button types.
  - Added clearer distinction between simple and detailed element actions with new titles: "Find element (simple)" and "Click element (detailed)".
  - Removed enumeration of click types ("left", "right", "middle") from simple string variants; these remain only in detailed object variants.
- **Chores**
  - Incremented package version to 3.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->